### PR TITLE
feat: add slug column + slug-aware lookups to Role and Permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $user->can('posts.publish');             // true (via Gate integration)
 | Field | Type | Notes |
 |---|---|---|
 | `name` | string | unique |
+| `slug` | string | unique; auto-derived from `name` via `Str::slug()` if not provided |
 | `description` | string\|null | |
 | `parent_id` | int\|null | foreign key to `roles.id`; `set null` on parent delete |
 
@@ -86,6 +87,8 @@ Relationships:
 - `parent()` → `BelongsTo Role`
 - `children()` → `HasMany Role`
 
+Slug helpers: `Role::findBySlug('editor')`, `Role::whereSlug('editor')->first()`. `hasRole('editor')` and `assignRole('editor')` match against either `name` or `slug`.
+
 Deleting a role detaches its permissions and nulls `parent_id` on its children.
 
 ### Permission
@@ -95,11 +98,14 @@ Deleting a role detaches its permissions and nulls `parent_id` on its children.
 | Field | Type | Notes |
 |---|---|---|
 | `name` | string | unique |
+| `slug` | string | unique; auto-derived from `name` via `Str::slug()` if not provided |
 | `description` | string\|null | |
 
 Relationships:
 
 - `roles()` → `BelongsToMany Role`
+
+Slug helpers: `Permission::findBySlug('pages.publish')`, `Permission::whereSlug('pages.publish')->first()`. `hasPermissionTo('pages.publish')` and the Gate integration both match against either `name` or `slug`.
 
 Deleting a permission detaches it from all roles.
 

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ The list of known permission slugs is cached for `artisanpack.rbac.cache.permiss
 ## Artisan commands
 
 ```bash
-php artisan role:create {name} [--description=...]
-php artisan permission:create {name} [--description=...]
+php artisan role:create {name} [--slug=...] [--description=...]
+php artisan permission:create {name} [--slug=...] [--description=...]
 php artisan user:assign-role {user} {role}
 php artisan user:revoke-role {user} {role}
 ```

--- a/config/artisanpack/rbac.php
+++ b/config/artisanpack/rbac.php
@@ -23,7 +23,7 @@ return [
     */
 
     'models' => [
-        'role'       => Role::class,
+        'role' => Role::class,
         'permission' => Permission::class,
     ],
 
@@ -40,9 +40,9 @@ return [
     */
 
     'tables' => [
-        'role_user'       => 'role_user',
+        'role_user' => 'role_user',
         'permission_role' => 'permission_role',
-        'users'           => 'users',
+        'users' => 'users',
     ],
 
     'foreign_keys' => [
@@ -62,7 +62,7 @@ return [
     |
     */
 
-    'user_lookup_fields' => [ 'email' ],
+    'user_lookup_fields' => ['email'],
 
     /*
     |--------------------------------------------------------------------------
@@ -79,7 +79,7 @@ return [
     'cache' => [
         'user_permissions_ttl' => 60,
         'permission_names_ttl' => 3600,
-        'tag'                  => 'rbac',
+        'tag' => 'rbac',
     ],
 
 ];

--- a/database/migrations/2025_11_30_164015_create_roles_table.php
+++ b/database/migrations/2025_11_30_164015_create_roles_table.php
@@ -6,13 +6,15 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         if (! Schema::hasTable('roles')) {
             Schema::create('roles', function (Blueprint $table): void {
                 $table->id();
                 $table->string('name')->unique();
+                $table->string('slug')->unique();
                 $table->string('description')->nullable();
                 $table->unsignedBigInteger('parent_id')->nullable();
                 $table->timestamps();

--- a/database/migrations/2025_11_30_164016_create_permissions_table.php
+++ b/database/migrations/2025_11_30_164016_create_permissions_table.php
@@ -6,13 +6,15 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         if (! Schema::hasTable('permissions')) {
             Schema::create('permissions', function (Blueprint $table): void {
                 $table->id();
                 $table->string('name')->unique();
+                $table->string('slug')->unique();
                 $table->string('description')->nullable();
                 $table->timestamps();
             });

--- a/database/migrations/2025_11_30_164017_create_permission_role_table.php
+++ b/database/migrations/2025_11_30_164017_create_permission_role_table.php
@@ -6,7 +6,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         if (! Schema::hasTable('permission_role')) {

--- a/database/migrations/2025_11_30_164018_create_role_user_table.php
+++ b/database/migrations/2025_11_30_164018_create_role_user_table.php
@@ -6,7 +6,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         if (! Schema::hasTable('role_user')) {

--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -22,8 +22,13 @@ trait HasPermissions
     {
         $permissions = $this->resolvePermissions();
 
-        return $permissions->contains('name', $permission)
-            || $permissions->contains('slug', $permission);
+        // Prefer name match; fall back to slug. This avoids ambiguity
+        // when one row's name happens to equal another row's slug.
+        if ($permissions->contains('name', $permission)) {
+            return true;
+        }
+
+        return $permissions->contains('slug', $permission);
     }
 
     /**

--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Concerns;
 
@@ -18,54 +18,57 @@ use Illuminate\Support\Facades\Cache;
  */
 trait HasPermissions
 {
-    public function hasPermissionTo( string $permission ): bool
+    public function hasPermissionTo(string $permission): bool
     {
-        return $this->resolvePermissions()->contains( 'name', $permission );
+        $permissions = $this->resolvePermissions();
+
+        return $permissions->contains('name', $permission)
+            || $permissions->contains('slug', $permission);
     }
 
     /**
      * Backwards-compatible alias retained for callers that still use the
      * pre-extraction method name.
      */
-    public function hasPermission( string $permission ): bool
+    public function hasPermission(string $permission): bool
     {
-        return $this->hasPermissionTo( $permission );
+        return $this->hasPermissionTo($permission);
     }
 
     public function flushPermissionCache(): void
     {
         $cacheKey = $this->permissionCacheKey();
 
-        if ( $this->cacheSupportsTagging() ) {
-            Cache::tags( [ config( 'artisanpack.rbac.cache.tag', 'rbac' ) ] )->forget( $cacheKey );
+        if ($this->cacheSupportsTagging()) {
+            Cache::tags([config('artisanpack.rbac.cache.tag', 'rbac')])->forget($cacheKey);
 
             return;
         }
 
-        Cache::forget( $cacheKey );
+        Cache::forget($cacheKey);
     }
 
     protected function resolvePermissions(): Collection
     {
         $cacheKey = $this->permissionCacheKey();
-        $ttl      = (int) config( 'artisanpack.rbac.cache.user_permissions_ttl', 60 );
-        $loader   = fn () => $this->loadAllPermissions();
+        $ttl = (int) config('artisanpack.rbac.cache.user_permissions_ttl', 60);
+        $loader = fn () => $this->loadAllPermissions();
 
-        if ( $this->cacheSupportsTagging() ) {
-            return Cache::tags( [ config( 'artisanpack.rbac.cache.tag', 'rbac' ) ] )
-                ->remember( $cacheKey, $ttl, $loader );
+        if ($this->cacheSupportsTagging()) {
+            return Cache::tags([config('artisanpack.rbac.cache.tag', 'rbac')])
+                ->remember($cacheKey, $ttl, $loader);
         }
 
-        return Cache::remember( $cacheKey, $ttl, $loader );
+        return Cache::remember($cacheKey, $ttl, $loader);
     }
 
     protected function loadAllPermissions(): Collection
     {
         $all = collect();
 
-        $this->roles->each( function ( $role ) use ( &$all ): void {
-            $all = $all->merge( $this->collectPermissionsForRole( $role ) );
-        } );
+        $this->roles->each(function ($role) use (&$all): void {
+            $all = $all->merge($this->collectPermissionsForRole($role));
+        });
 
         return $all;
     }
@@ -73,17 +76,17 @@ trait HasPermissions
     /**
      * @param  array<int, int>  $visited
      */
-    protected function collectPermissionsForRole( Role $role, array $visited = [] ): Collection
+    protected function collectPermissionsForRole(Role $role, array $visited = []): Collection
     {
-        if ( in_array( $role->getKey(), $visited, true ) ) {
+        if (in_array($role->getKey(), $visited, true)) {
             return collect();
         }
 
-        $visited[]   = $role->getKey();
+        $visited[] = $role->getKey();
         $permissions = $role->permissions;
 
-        if ( $role->parent ) {
-            $permissions = $permissions->merge( $this->collectPermissionsForRole( $role->parent, $visited ) );
+        if ($role->parent) {
+            $permissions = $permissions->merge($this->collectPermissionsForRole($role->parent, $visited));
         }
 
         return $permissions;
@@ -96,6 +99,6 @@ trait HasPermissions
 
     protected function permissionCacheKey(): string
     {
-        return 'permissions_for_user_' . $this->getKey();
+        return 'permissions_for_user_'.$this->getKey();
     }
 }

--- a/src/Concerns/HasRoles.php
+++ b/src/Concerns/HasRoles.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Concerns;
 
@@ -29,31 +29,32 @@ trait HasRoles
         );
     }
 
-    public function hasRole( Role|string|Collection $role ): bool
+    public function hasRole(Role|string|Collection $role): bool
     {
-        if ( is_string( $role ) ) {
-            return $this->roles->contains( 'name', $role );
+        if (is_string($role)) {
+            return $this->roles->contains('name', $role)
+                || $this->roles->contains('slug', $role);
         }
 
-        if ( $role instanceof Role ) {
-            return $this->roles->contains( 'id', $role->getKey() );
+        if ($role instanceof Role) {
+            return $this->roles->contains('id', $role->getKey());
         }
 
         $incomingIds = $role->map->getKey()->all();
-        $currentIds  = $this->roles->map->getKey()->all();
+        $currentIds = $this->roles->map->getKey()->all();
 
-        return count( array_intersect( $incomingIds, $currentIds ) ) > 0;
+        return count(array_intersect($incomingIds, $currentIds)) > 0;
     }
 
-    public function assignRole( Role|string $role ): static
+    public function assignRole(Role|string $role): static
     {
-        $resolved = $this->resolveRoleInstance( $role );
+        $resolved = $this->resolveRoleInstance($role);
 
-        if ( null !== $resolved ) {
-            $this->roles()->syncWithoutDetaching( [ $resolved->getKey() ] );
-            Event::dispatch( 'rbac.user.role_assigned', [ $this, $resolved ] );
+        if ($resolved !== null) {
+            $this->roles()->syncWithoutDetaching([$resolved->getKey()]);
+            Event::dispatch('rbac.user.role_assigned', [$this, $resolved]);
 
-            if ( method_exists( $this, 'flushPermissionCache' ) ) {
+            if (method_exists($this, 'flushPermissionCache')) {
                 $this->flushPermissionCache();
             }
         }
@@ -61,15 +62,15 @@ trait HasRoles
         return $this;
     }
 
-    public function removeRole( Role|string $role ): static
+    public function removeRole(Role|string $role): static
     {
-        $resolved = $this->resolveRoleInstance( $role );
+        $resolved = $this->resolveRoleInstance($role);
 
-        if ( null !== $resolved ) {
-            $this->roles()->detach( $resolved->getKey() );
-            Event::dispatch( 'rbac.user.role_removed', [ $this, $resolved ] );
+        if ($resolved !== null) {
+            $this->roles()->detach($resolved->getKey());
+            Event::dispatch('rbac.user.role_removed', [$this, $resolved]);
 
-            if ( method_exists( $this, 'flushPermissionCache' ) ) {
+            if (method_exists($this, 'flushPermissionCache')) {
                 $this->flushPermissionCache();
             }
         }
@@ -79,12 +80,12 @@ trait HasRoles
 
     protected function getRoleUserPivotTable(): string
     {
-        return config( 'artisanpack.rbac.tables.role_user', 'role_user' );
+        return config('artisanpack.rbac.tables.role_user', 'role_user');
     }
 
     protected function getRoleUserForeignKey(): string
     {
-        return config( 'artisanpack.rbac.foreign_keys.user', 'user_id' );
+        return config('artisanpack.rbac.foreign_keys.user', 'user_id');
     }
 
     /**
@@ -92,17 +93,20 @@ trait HasRoles
      */
     protected function resolveRoleModel(): string
     {
-        return config( 'artisanpack.rbac.models.role', Role::class );
+        return config('artisanpack.rbac.models.role', Role::class);
     }
 
-    protected function resolveRoleInstance( Role|string $role ): ?Role
+    protected function resolveRoleInstance(Role|string $role): ?Role
     {
-        if ( $role instanceof Role ) {
+        if ($role instanceof Role) {
             return $role;
         }
 
         $model = $this->resolveRoleModel();
 
-        return $model::where( 'name', $role )->first();
+        return $model::query()
+            ->where('name', $role)
+            ->orWhere('slug', $role)
+            ->first();
     }
 }

--- a/src/Concerns/HasRoles.php
+++ b/src/Concerns/HasRoles.php
@@ -32,8 +32,13 @@ trait HasRoles
     public function hasRole(Role|string|Collection $role): bool
     {
         if (is_string($role)) {
-            return $this->roles->contains('name', $role)
-                || $this->roles->contains('slug', $role);
+            // Prefer name match; fall back to slug. This avoids ambiguity
+            // when one row's name happens to equal another row's slug.
+            if ($this->roles->contains('name', $role)) {
+                return true;
+            }
+
+            return $this->roles->contains('slug', $role);
         }
 
         if ($role instanceof Role) {
@@ -104,9 +109,10 @@ trait HasRoles
 
         $model = $this->resolveRoleModel();
 
-        return $model::query()
-            ->where('name', $role)
-            ->orWhere('slug', $role)
-            ->first();
+        // Prefer name match; fall back to slug. Two queries instead of an
+        // orWhere so a `name === other-row's-slug` collision can't return
+        // the wrong row.
+        return $model::query()->where('name', $role)->first()
+            ?? $model::query()->where('slug', $role)->first();
     }
 }

--- a/src/Console/Commands/AssignRole.php
+++ b/src/Console/Commands/AssignRole.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Schema;
 
 class AssignRole extends Command
 {
-    protected $signature = 'user:assign-role {user : The user ID, email, or username} {role : The role name}';
+    protected $signature = 'user:assign-role {user : The user ID, email, or username} {role : The role name or slug}';
 
     protected $description = 'Assign a role to a user';
 
@@ -21,7 +21,11 @@ class AssignRole extends Command
         $roleModel = config('artisanpack.rbac.models.role', Role::class);
 
         $userArgument = $this->argument('user');
-        $role = $roleModel::where('name', $this->argument('role'))->first();
+        $roleArgument = $this->argument('role');
+        // Name first, slug fallback — two queries so a name/slug collision
+        // can't resolve to the wrong row.
+        $role = $roleModel::where('name', $roleArgument)->first()
+            ?? $roleModel::where('slug', $roleArgument)->first();
 
         $user = $this->resolveUser($userModel, $userArgument);
 

--- a/src/Console/Commands/AssignRole.php
+++ b/src/Console/Commands/AssignRole.php
@@ -1,11 +1,13 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Console\Commands;
 
 use ArtisanPackUI\Rbac\Models\Role;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
 
 class AssignRole extends Command
 {
@@ -15,33 +17,33 @@ class AssignRole extends Command
 
     public function handle(): int
     {
-        $userModel = config( 'auth.providers.users.model' );
-        $roleModel = config( 'artisanpack.rbac.models.role', Role::class );
+        $userModel = config('auth.providers.users.model');
+        $roleModel = config('artisanpack.rbac.models.role', Role::class);
 
-        $userArgument = $this->argument( 'user' );
-        $role         = $roleModel::where( 'name', $this->argument( 'role' ) )->first();
+        $userArgument = $this->argument('user');
+        $role = $roleModel::where('name', $this->argument('role'))->first();
 
-        $user = $this->resolveUser( $userModel, $userArgument );
+        $user = $this->resolveUser($userModel, $userArgument);
 
-        if ( ! $user ) {
-            $this->error( 'User not found.' );
-
-            return self::FAILURE;
-        }
-
-        if ( ! $role ) {
-            $this->error( 'Role not found.' );
+        if (! $user) {
+            $this->error('User not found.');
 
             return self::FAILURE;
         }
 
-        $user->roles()->syncWithoutDetaching( [ $role->getKey() ] );
+        if (! $role) {
+            $this->error('Role not found.');
 
-        if ( method_exists( $user, 'flushPermissionCache' ) ) {
+            return self::FAILURE;
+        }
+
+        $user->roles()->syncWithoutDetaching([$role->getKey()]);
+
+        if (method_exists($user, 'flushPermissionCache')) {
             $user->flushPermissionCache();
         }
 
-        $this->info( "Role `{$role->name}` assigned to user `{$user->name}` successfully." );
+        $this->info("Role `{$role->name}` assigned to user `{$user->name}` successfully.");
 
         return self::SUCCESS;
     }
@@ -51,26 +53,26 @@ class AssignRole extends Command
      * fields. Skips lookup fields whose columns are missing on the users
      * table so this works against any standard Laravel schema.
      *
-     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $userModel
+     * @param  class-string<Model>  $userModel
      */
-    protected function resolveUser( string $userModel, string $identifier )
+    protected function resolveUser(string $userModel, string $identifier)
     {
-        if ( is_numeric( $identifier ) ) {
-            return $userModel::find( $identifier );
+        if (is_numeric($identifier)) {
+            return $userModel::find($identifier);
         }
 
-        $table  = ( new $userModel() )->getTable();
-        $fields = (array) config( 'artisanpack.rbac.user_lookup_fields', [ 'email' ] );
+        $table = (new $userModel)->getTable();
+        $fields = (array) config('artisanpack.rbac.user_lookup_fields', ['email']);
 
         $query = $userModel::query();
-        $any   = false;
+        $any = false;
 
-        foreach ( $fields as $field ) {
-            if ( ! \Illuminate\Support\Facades\Schema::hasColumn( $table, $field ) ) {
+        foreach ($fields as $field) {
+            if (! Schema::hasColumn($table, $field)) {
                 continue;
             }
 
-            $query->orWhere( $field, $identifier );
+            $query->orWhere($field, $identifier);
             $any = true;
         }
 

--- a/src/Console/Commands/CreatePermission.php
+++ b/src/Console/Commands/CreatePermission.php
@@ -9,7 +9,7 @@ use Illuminate\Console\Command;
 
 class CreatePermission extends Command
 {
-    protected $signature = 'permission:create {name} {--description=}';
+    protected $signature = 'permission:create {name} {--slug=} {--description=}';
 
     protected $description = 'Create a new permission';
 
@@ -18,10 +18,14 @@ class CreatePermission extends Command
         $model = config('artisanpack.rbac.models.permission', Permission::class);
 
         $permission = $model::create(
-            [
-                'name' => $this->argument('name'),
-                'description' => $this->option('description'),
-            ],
+            array_filter(
+                [
+                    'name' => $this->argument('name'),
+                    'slug' => $this->option('slug'),
+                    'description' => $this->option('description'),
+                ],
+                fn ($value) => $value !== null && $value !== '',
+            ),
         );
 
         $this->info("Permission `{$permission->name}` created successfully.");

--- a/src/Console/Commands/CreatePermission.php
+++ b/src/Console/Commands/CreatePermission.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Console\Commands;
 
@@ -15,16 +15,16 @@ class CreatePermission extends Command
 
     public function handle(): int
     {
-        $model = config( 'artisanpack.rbac.models.permission', Permission::class );
+        $model = config('artisanpack.rbac.models.permission', Permission::class);
 
         $permission = $model::create(
             [
-                'name'        => $this->argument( 'name' ),
-                'description' => $this->option( 'description' ),
+                'name' => $this->argument('name'),
+                'description' => $this->option('description'),
             ],
         );
 
-        $this->info( "Permission `{$permission->name}` created successfully." );
+        $this->info("Permission `{$permission->name}` created successfully.");
 
         return self::SUCCESS;
     }

--- a/src/Console/Commands/CreatePermission.php
+++ b/src/Console/Commands/CreatePermission.php
@@ -17,13 +17,18 @@ class CreatePermission extends Command
     {
         $model = config('artisanpack.rbac.models.permission', Permission::class);
 
+        $payload = array_map(
+            fn ($value) => is_string($value) ? trim($value) : $value,
+            [
+                'name' => $this->argument('name'),
+                'slug' => $this->option('slug'),
+                'description' => $this->option('description'),
+            ],
+        );
+
         $permission = $model::create(
             array_filter(
-                [
-                    'name' => $this->argument('name'),
-                    'slug' => $this->option('slug'),
-                    'description' => $this->option('description'),
-                ],
+                $payload,
                 fn ($value) => $value !== null && $value !== '',
             ),
         );

--- a/src/Console/Commands/CreateRole.php
+++ b/src/Console/Commands/CreateRole.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Console\Commands;
 
@@ -15,16 +15,16 @@ class CreateRole extends Command
 
     public function handle(): int
     {
-        $model = config( 'artisanpack.rbac.models.role', Role::class );
+        $model = config('artisanpack.rbac.models.role', Role::class);
 
         $role = $model::create(
             [
-                'name'        => $this->argument( 'name' ),
-                'description' => $this->option( 'description' ),
+                'name' => $this->argument('name'),
+                'description' => $this->option('description'),
             ],
         );
 
-        $this->info( "Role `{$role->name}` created successfully." );
+        $this->info("Role `{$role->name}` created successfully.");
 
         return self::SUCCESS;
     }

--- a/src/Console/Commands/CreateRole.php
+++ b/src/Console/Commands/CreateRole.php
@@ -17,13 +17,18 @@ class CreateRole extends Command
     {
         $model = config('artisanpack.rbac.models.role', Role::class);
 
+        $payload = array_map(
+            fn ($value) => is_string($value) ? trim($value) : $value,
+            [
+                'name' => $this->argument('name'),
+                'slug' => $this->option('slug'),
+                'description' => $this->option('description'),
+            ],
+        );
+
         $role = $model::create(
             array_filter(
-                [
-                    'name' => $this->argument('name'),
-                    'slug' => $this->option('slug'),
-                    'description' => $this->option('description'),
-                ],
+                $payload,
                 fn ($value) => $value !== null && $value !== '',
             ),
         );

--- a/src/Console/Commands/CreateRole.php
+++ b/src/Console/Commands/CreateRole.php
@@ -9,7 +9,7 @@ use Illuminate\Console\Command;
 
 class CreateRole extends Command
 {
-    protected $signature = 'role:create {name} {--description=}';
+    protected $signature = 'role:create {name} {--slug=} {--description=}';
 
     protected $description = 'Create a new role';
 
@@ -18,10 +18,14 @@ class CreateRole extends Command
         $model = config('artisanpack.rbac.models.role', Role::class);
 
         $role = $model::create(
-            [
-                'name' => $this->argument('name'),
-                'description' => $this->option('description'),
-            ],
+            array_filter(
+                [
+                    'name' => $this->argument('name'),
+                    'slug' => $this->option('slug'),
+                    'description' => $this->option('description'),
+                ],
+                fn ($value) => $value !== null && $value !== '',
+            ),
         );
 
         $this->info("Role `{$role->name}` created successfully.");

--- a/src/Console/Commands/RevokeRole.php
+++ b/src/Console/Commands/RevokeRole.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Schema;
 
 class RevokeRole extends Command
 {
-    protected $signature = 'user:revoke-role {user : The user ID, email, or username} {role : The role name}';
+    protected $signature = 'user:revoke-role {user : The user ID, email, or username} {role : The role name or slug}';
 
     protected $description = 'Revoke a role from a user';
 
@@ -21,7 +21,11 @@ class RevokeRole extends Command
         $roleModel = config('artisanpack.rbac.models.role', Role::class);
 
         $userArgument = $this->argument('user');
-        $role = $roleModel::where('name', $this->argument('role'))->first();
+        $roleArgument = $this->argument('role');
+        // Name first, slug fallback — two queries so a name/slug collision
+        // can't resolve to the wrong row.
+        $role = $roleModel::where('name', $roleArgument)->first()
+            ?? $roleModel::where('slug', $roleArgument)->first();
 
         $user = $this->resolveUser($userModel, $userArgument);
 

--- a/src/Console/Commands/RevokeRole.php
+++ b/src/Console/Commands/RevokeRole.php
@@ -1,11 +1,13 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Console\Commands;
 
 use ArtisanPackUI\Rbac\Models\Role;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
 
 class RevokeRole extends Command
 {
@@ -15,33 +17,33 @@ class RevokeRole extends Command
 
     public function handle(): int
     {
-        $userModel = config( 'auth.providers.users.model' );
-        $roleModel = config( 'artisanpack.rbac.models.role', Role::class );
+        $userModel = config('auth.providers.users.model');
+        $roleModel = config('artisanpack.rbac.models.role', Role::class);
 
-        $userArgument = $this->argument( 'user' );
-        $role         = $roleModel::where( 'name', $this->argument( 'role' ) )->first();
+        $userArgument = $this->argument('user');
+        $role = $roleModel::where('name', $this->argument('role'))->first();
 
-        $user = $this->resolveUser( $userModel, $userArgument );
+        $user = $this->resolveUser($userModel, $userArgument);
 
-        if ( ! $user ) {
-            $this->error( 'User not found.' );
-
-            return self::FAILURE;
-        }
-
-        if ( ! $role ) {
-            $this->error( 'Role not found.' );
+        if (! $user) {
+            $this->error('User not found.');
 
             return self::FAILURE;
         }
 
-        $user->roles()->detach( $role->getKey() );
+        if (! $role) {
+            $this->error('Role not found.');
 
-        if ( method_exists( $user, 'flushPermissionCache' ) ) {
+            return self::FAILURE;
+        }
+
+        $user->roles()->detach($role->getKey());
+
+        if (method_exists($user, 'flushPermissionCache')) {
             $user->flushPermissionCache();
         }
 
-        $this->info( "Role `{$role->name}` revoked from user `{$user->name}` successfully." );
+        $this->info("Role `{$role->name}` revoked from user `{$user->name}` successfully.");
 
         return self::SUCCESS;
     }
@@ -51,26 +53,26 @@ class RevokeRole extends Command
      * fields. Skips lookup fields whose columns are missing on the users
      * table so this works against any standard Laravel schema.
      *
-     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $userModel
+     * @param  class-string<Model>  $userModel
      */
-    protected function resolveUser( string $userModel, string $identifier )
+    protected function resolveUser(string $userModel, string $identifier)
     {
-        if ( is_numeric( $identifier ) ) {
-            return $userModel::find( $identifier );
+        if (is_numeric($identifier)) {
+            return $userModel::find($identifier);
         }
 
-        $table  = ( new $userModel() )->getTable();
-        $fields = (array) config( 'artisanpack.rbac.user_lookup_fields', [ 'email' ] );
+        $table = (new $userModel)->getTable();
+        $fields = (array) config('artisanpack.rbac.user_lookup_fields', ['email']);
 
         $query = $userModel::query();
-        $any   = false;
+        $any = false;
 
-        foreach ( $fields as $field ) {
-            if ( ! \Illuminate\Support\Facades\Schema::hasColumn( $table, $field ) ) {
+        foreach ($fields as $field) {
+            if (! Schema::hasColumn($table, $field)) {
                 continue;
             }
 
-            $query->orWhere( $field, $identifier );
+            $query->orWhere($field, $identifier);
             $any = true;
         }
 

--- a/src/Facades/Rbac.php
+++ b/src/Facades/Rbac.php
@@ -5,13 +5,11 @@
  *
  * Provides static access to the Rbac class.
  *
- * @package    ArtisanPack_UI
- * @subpackage Rbac
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Facades;
 
@@ -21,10 +19,6 @@ use Illuminate\Support\Facades\Facade;
  * Rbac Facade.
  *
  * @see \ArtisanPackUI\Rbac\Rbac
- *
- * @package    ArtisanPack_UI
- * @subpackage Rbac
- *
  * @since      1.0.0
  */
 class Rbac extends Facade
@@ -33,8 +27,6 @@ class Rbac extends Facade
      * Get the registered name of the component.
      *
      * @since 1.0.0
-     *
-     * @return string
      */
     protected static function getFacadeAccessor(): string
     {

--- a/src/Http/Middleware/CheckPermission.php
+++ b/src/Http/Middleware/CheckPermission.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Http\Middleware;
 
@@ -19,20 +19,20 @@ use Illuminate\Support\Facades\Auth;
  */
 class CheckPermission
 {
-    public function handle( Request $request, Closure $next, string ...$permissions )
+    public function handle(Request $request, Closure $next, string ...$permissions)
     {
-        if ( Auth::guest() ) {
-            abort( 401 );
+        if (Auth::guest()) {
+            abort(401);
         }
 
         $user = Auth::user();
 
-        foreach ( $permissions as $permission ) {
-            if ( $user->can( $permission ) ) {
-                return $next( $request );
+        foreach ($permissions as $permission) {
+            if ($user->can($permission)) {
+                return $next($request);
             }
         }
 
-        abort( 403 );
+        abort(403);
     }
 }

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -1,11 +1,13 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Str;
 
 /**
  * Permission model — represents an atomic capability that can be granted
@@ -18,23 +20,43 @@ class Permission extends Model
 {
     protected $fillable = [
         'name',
+        'slug',
         'description',
     ];
 
     public function roles(): BelongsToMany
     {
         return $this->belongsToMany(
-            config( 'artisanpack.rbac.models.role', Role::class ),
-            config( 'artisanpack.rbac.tables.permission_role', 'permission_role' ),
+            config('artisanpack.rbac.models.role', Role::class),
+            config('artisanpack.rbac.tables.permission_role', 'permission_role'),
         );
+    }
+
+    public function scopeWhereSlug(Builder $query, string $slug): Builder
+    {
+        return $query->where('slug', $slug);
+    }
+
+    public static function findBySlug(string $slug): ?static
+    {
+        return static::query()->where('slug', $slug)->first();
+    }
+
+    public function save(array $options = []): bool
+    {
+        if (empty($this->slug) && ! empty($this->name)) {
+            $this->slug = Str::slug($this->name);
+        }
+
+        return parent::save($options);
     }
 
     protected static function boot(): void
     {
         parent::boot();
 
-        static::deleting( function ( $permission ): void {
+        static::deleting(function ($permission): void {
             $permission->roles()->detach();
-        } );
+        });
     }
 }

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -48,7 +48,46 @@ class Permission extends Model
             $this->slug = Str::slug($this->name);
         }
 
+        $this->guardAgainstNameSlugCollision();
+
         return parent::save($options);
+    }
+
+    /**
+     * Reject saves where this row's name matches another row's slug, or
+     * vice versa. The DB unique constraint already covers same-column
+     * duplicates; this catches the cross-column case so name-first /
+     * slug-fallback lookups remain unambiguous.
+     */
+    protected function guardAgainstNameSlugCollision(): void
+    {
+        if (empty($this->name) || empty($this->slug)) {
+            return;
+        }
+
+        $key = $this->getKey();
+
+        $collision = static::query()
+            ->where(function ($query): void {
+                $query->where('name', $this->slug)
+                    ->orWhere('slug', $this->name);
+            })
+            ->when($key !== null, fn ($query) => $query->where($this->getKeyName(), '!=', $key))
+            ->where(function ($query): void {
+                // Self-overlap (name === slug on this same row) is fine —
+                // it's the most common case post auto-derivation.
+                $query->where('name', '!=', $this->name)
+                    ->orWhere('slug', '!=', $this->slug);
+            })
+            ->exists();
+
+        if ($collision) {
+            throw new \RuntimeException(sprintf(
+                'Permission name/slug collision: another row already uses "%s" or "%s" in the opposite column.',
+                $this->name,
+                $this->slug,
+            ));
+        }
     }
 
     protected static function boot(): void

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -1,13 +1,15 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 
 /**
  * Role model — represents a named bundle of permissions optionally arranged
@@ -20,45 +22,65 @@ class Role extends Model
 {
     protected $fillable = [
         'name',
+        'slug',
         'description',
         'parent_id',
     ];
 
+    public function scopeWhereSlug(Builder $query, string $slug): Builder
+    {
+        return $query->where('slug', $slug);
+    }
+
+    public static function findBySlug(string $slug): ?static
+    {
+        return static::query()->where('slug', $slug)->first();
+    }
+
     public function permissions(): BelongsToMany
     {
         return $this->belongsToMany(
-            config( 'artisanpack.rbac.models.permission', Permission::class ),
-            config( 'artisanpack.rbac.tables.permission_role', 'permission_role' ),
+            config('artisanpack.rbac.models.permission', Permission::class),
+            config('artisanpack.rbac.tables.permission_role', 'permission_role'),
         );
     }
 
     public function users(): BelongsToMany
     {
         return $this->belongsToMany(
-            config( 'auth.providers.users.model' ),
-            config( 'artisanpack.rbac.tables.role_user', 'role_user' ),
+            config('auth.providers.users.model'),
+            config('artisanpack.rbac.tables.role_user', 'role_user'),
             'role_id',
-            config( 'artisanpack.rbac.foreign_keys.user', 'user_id' ),
+            config('artisanpack.rbac.foreign_keys.user', 'user_id'),
         );
     }
 
     public function parent(): BelongsTo
     {
-        return $this->belongsTo( static::class, 'parent_id' );
+        return $this->belongsTo(static::class, 'parent_id');
     }
 
     public function children(): HasMany
     {
-        return $this->hasMany( static::class, 'parent_id' );
+        return $this->hasMany(static::class, 'parent_id');
+    }
+
+    public function save(array $options = []): bool
+    {
+        if (empty($this->slug) && ! empty($this->name)) {
+            $this->slug = Str::slug($this->name);
+        }
+
+        return parent::save($options);
     }
 
     protected static function boot(): void
     {
         parent::boot();
 
-        static::deleting( function ( $role ): void {
+        static::deleting(function ($role): void {
             $role->permissions()->detach();
             $role->users()->detach();
-        } );
+        });
     }
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -71,7 +71,46 @@ class Role extends Model
             $this->slug = Str::slug($this->name);
         }
 
+        $this->guardAgainstNameSlugCollision();
+
         return parent::save($options);
+    }
+
+    /**
+     * Reject saves where this row's name matches another row's slug, or
+     * vice versa. The DB unique constraint already covers same-column
+     * duplicates; this catches the cross-column case so name-first /
+     * slug-fallback lookups remain unambiguous.
+     */
+    protected function guardAgainstNameSlugCollision(): void
+    {
+        if (empty($this->name) || empty($this->slug)) {
+            return;
+        }
+
+        $key = $this->getKey();
+
+        $collision = static::query()
+            ->where(function ($query): void {
+                $query->where('name', $this->slug)
+                    ->orWhere('slug', $this->name);
+            })
+            ->when($key !== null, fn ($query) => $query->where($this->getKeyName(), '!=', $key))
+            ->where(function ($query): void {
+                // Self-overlap (name === slug on this same row) is fine —
+                // it's the most common case post auto-derivation.
+                $query->where('name', '!=', $this->name)
+                    ->orWhere('slug', '!=', $this->slug);
+            })
+            ->exists();
+
+        if ($collision) {
+            throw new \RuntimeException(sprintf(
+                'Role name/slug collision: another row already uses "%s" or "%s" in the opposite column.',
+                $this->name,
+                $this->slug,
+            ));
+        }
     }
 
     protected static function boot(): void

--- a/src/Observers/PermissionObserver.php
+++ b/src/Observers/PermissionObserver.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Observers;
 
@@ -15,21 +15,21 @@ use Illuminate\Support\Facades\Event;
  */
 class PermissionObserver
 {
-    public function created( Permission $permission ): void
+    public function created(Permission $permission): void
     {
-        Event::dispatch( 'rbac.permission.created', [ $permission ] );
+        Event::dispatch('rbac.permission.created', [$permission]);
     }
 
-    public function updated( Permission $permission ): void
+    public function updated(Permission $permission): void
     {
         Event::dispatch(
             'rbac.permission.updated',
-            [ $permission, $permission->getChanges(), $permission->getOriginal() ],
+            [$permission, $permission->getChanges(), $permission->getOriginal()],
         );
     }
 
-    public function deleted( Permission $permission ): void
+    public function deleted(Permission $permission): void
     {
-        Event::dispatch( 'rbac.permission.deleted', [ $permission ] );
+        Event::dispatch('rbac.permission.deleted', [$permission]);
     }
 }

--- a/src/Observers/RoleObserver.php
+++ b/src/Observers/RoleObserver.php
@@ -1,9 +1,10 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac\Observers;
 
+use ArtisanPackUI\Rbac\Concerns\HasRoles;
 use ArtisanPackUI\Rbac\Models\Role;
 use Illuminate\Support\Facades\Event;
 
@@ -11,24 +12,24 @@ use Illuminate\Support\Facades\Event;
  * Role observer — emits package-level events when role records change.
  * Consumers (e.g. security-analytics) listen on the `rbac.role.*` channel
  * to layer on auditing. Pivot mutations are dispatched directly from
- * {@see \ArtisanPackUI\Rbac\Concerns\HasRoles::assignRole()} and
- * {@see \ArtisanPackUI\Rbac\Concerns\HasRoles::removeRole()} on the
+ * {@see HasRoles::assignRole()} and
+ * {@see HasRoles::removeRole()} on the
  * `rbac.user.role_*` channel since Laravel does not fire pivot events.
  */
 class RoleObserver
 {
-    public function created( Role $role ): void
+    public function created(Role $role): void
     {
-        Event::dispatch( 'rbac.role.created', [ $role ] );
+        Event::dispatch('rbac.role.created', [$role]);
     }
 
-    public function updated( Role $role ): void
+    public function updated(Role $role): void
     {
-        Event::dispatch( 'rbac.role.updated', [ $role, $role->getChanges(), $role->getOriginal() ] );
+        Event::dispatch('rbac.role.updated', [$role, $role->getChanges(), $role->getOriginal()]);
     }
 
-    public function deleted( Role $role ): void
+    public function deleted(Role $role): void
     {
-        Event::dispatch( 'rbac.role.deleted', [ $role ] );
+        Event::dispatch('rbac.role.deleted', [$role]);
     }
 }

--- a/src/Rbac.php
+++ b/src/Rbac.php
@@ -6,13 +6,11 @@
  * This is the main class for the package, accessed via the 'rbac' helper
  * function or the Rbac facade.
  *
- * @package    ArtisanPack_UI
- * @subpackage Rbac
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac;
 
@@ -22,8 +20,6 @@ namespace ArtisanPackUI\Rbac;
  * Add public API methods (role/permission lookups, etc.) here as the
  * package matures.
  *
- * @package    ArtisanPack_UI
- * @subpackage Rbac
  *
  * @since      1.0.0
  */

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -7,15 +7,13 @@
  * middleware aliases, Artisan commands, Blade directives, and Gate
  * integration.
  *
- * @package    ArtisanPack_UI
- * @subpackage Rbac
  *
  * @author     Jacob Martella <me@jacobmartella.com>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Rbac;
 
@@ -37,8 +35,6 @@ use Illuminate\Support\ServiceProvider;
 /**
  * Service provider for the Rbac package.
  *
- * @package    ArtisanPack_UI
- * @subpackage Rbac
  *
  * @since      1.0.0
  */
@@ -48,38 +44,34 @@ class RbacServiceProvider extends ServiceProvider
      * Registers any application services.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/artisanpack/rbac.php',
+            __DIR__.'/../config/artisanpack/rbac.php',
             'artisanpack.rbac',
         );
 
-        $this->app->singleton( 'rbac', function ( $app ) {
-            return new Rbac();
-        } );
+        $this->app->singleton('rbac', function ($app) {
+            return new Rbac;
+        });
     }
 
     /**
      * Bootstraps any application services.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function boot(): void
     {
         $this->publishes(
             [
-                __DIR__ . '/../config/artisanpack/rbac.php' => config_path( 'artisanpack/rbac.php' ),
+                __DIR__.'/../config/artisanpack/rbac.php' => config_path('artisanpack/rbac.php'),
             ],
             'rbac-config',
         );
 
-        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
         $this->registerObservers();
         $this->registerMiddleware();
@@ -94,11 +86,11 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerObservers(): void
     {
-        $roleModel       = config( 'artisanpack.rbac.models.role', Role::class );
-        $permissionModel = config( 'artisanpack.rbac.models.permission', Permission::class );
+        $roleModel = config('artisanpack.rbac.models.role', Role::class);
+        $permissionModel = config('artisanpack.rbac.models.permission', Permission::class);
 
-        $roleModel::observe( RoleObserver::class );
-        $permissionModel::observe( PermissionObserver::class );
+        $roleModel::observe(RoleObserver::class);
+        $permissionModel::observe(PermissionObserver::class);
     }
 
     /**
@@ -106,7 +98,7 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerMiddleware(): void
     {
-        $this->app['router']->aliasMiddleware( 'permission', CheckPermission::class );
+        $this->app['router']->aliasMiddleware('permission', CheckPermission::class);
     }
 
     /**
@@ -114,7 +106,7 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerCommands(): void
     {
-        if ( ! $this->app->runningInConsole() ) {
+        if (! $this->app->runningInConsole()) {
             return;
         }
 
@@ -133,21 +125,21 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerBladeDirectives(): void
     {
-        Blade::directive( 'role', function ( $role ) {
+        Blade::directive('role', function ($role) {
             return "<?php if(auth()->check() && method_exists(auth()->user(), 'hasRole') && auth()->user()->hasRole({$role})): ?>";
-        } );
+        });
 
-        Blade::directive( 'endrole', function () {
+        Blade::directive('endrole', function () {
             return '<?php endif; ?>';
-        } );
+        });
 
-        Blade::directive( 'permission', function ( $permission ) {
+        Blade::directive('permission', function ($permission) {
             return "<?php if(auth()->check() && auth()->user()->can({$permission})): ?>";
-        } );
+        });
 
-        Blade::directive( 'endpermission', function () {
+        Blade::directive('endpermission', function () {
             return '<?php endif; ?>';
-        } );
+        });
     }
 
     /**
@@ -157,19 +149,19 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerGate(): void
     {
-        Gate::before( function ( $user, $ability ) {
-            if ( ! method_exists( $user, 'hasPermissionTo' ) ) {
+        Gate::before(function ($user, $ability) {
+            if (! method_exists($user, 'hasPermissionTo')) {
                 return null;
             }
 
             $permissionNames = $this->getCachedPermissionNames();
 
-            if ( in_array( $ability, $permissionNames, true ) ) {
-                return $user->hasPermissionTo( $ability );
+            if (in_array($ability, $permissionNames, true)) {
+                return $user->hasPermissionTo($ability);
             }
 
             return null;
-        } );
+        });
     }
 
     /**
@@ -178,11 +170,11 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerPermissionCacheInvalidators(): void
     {
-        $permissionModel = config( 'artisanpack.rbac.models.permission', Permission::class );
+        $permissionModel = config('artisanpack.rbac.models.permission', Permission::class);
 
-        $permissionModel::created( fn () => $this->flushPermissionNamesCache() );
-        $permissionModel::updated( fn () => $this->flushPermissionNamesCache() );
-        $permissionModel::deleted( fn () => $this->flushPermissionNamesCache() );
+        $permissionModel::created(fn () => $this->flushPermissionNamesCache());
+        $permissionModel::updated(fn () => $this->flushPermissionNamesCache());
+        $permissionModel::deleted(fn () => $this->flushPermissionNamesCache());
     }
 
     /**
@@ -192,16 +184,22 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function getCachedPermissionNames(): array
     {
-        $permissionModel = config( 'artisanpack.rbac.models.permission', Permission::class );
-        $cacheKey        = 'rbac_permission_names';
-        $ttl             = (int) config( 'artisanpack.rbac.cache.permission_names_ttl', 3600 );
+        $permissionModel = config('artisanpack.rbac.models.permission', Permission::class);
+        $cacheKey = 'rbac_permission_names';
+        $ttl = (int) config('artisanpack.rbac.cache.permission_names_ttl', 3600);
 
-        if ( Cache::getStore() instanceof TaggableStore ) {
-            return Cache::tags( [ config( 'artisanpack.rbac.cache.tag', 'rbac' ) ] )
-                ->remember( $cacheKey, $ttl, fn () => $permissionModel::pluck( 'name' )->toArray() );
+        if (Cache::getStore() instanceof TaggableStore) {
+            return Cache::tags([config('artisanpack.rbac.cache.tag', 'rbac')])
+                ->remember($cacheKey, $ttl, fn () => array_values(array_unique(array_merge(
+                    $permissionModel::pluck('name')->toArray(),
+                    $permissionModel::pluck('slug')->toArray(),
+                ))));
         }
 
-        return Cache::remember( $cacheKey, $ttl, fn () => $permissionModel::pluck( 'name' )->toArray() );
+        return Cache::remember($cacheKey, $ttl, fn () => array_values(array_unique(array_merge(
+            $permissionModel::pluck('name')->toArray(),
+            $permissionModel::pluck('slug')->toArray(),
+        ))));
     }
 
     /**
@@ -210,14 +208,14 @@ class RbacServiceProvider extends ServiceProvider
     protected function flushPermissionNamesCache(): void
     {
         $cacheKey = 'rbac_permission_names';
-        $tag      = config( 'artisanpack.rbac.cache.tag', 'rbac' );
+        $tag = config('artisanpack.rbac.cache.tag', 'rbac');
 
-        if ( Cache::getStore() instanceof TaggableStore ) {
-            Cache::tags( [ $tag ] )->forget( $cacheKey );
+        if (Cache::getStore() instanceof TaggableStore) {
+            Cache::tags([$tag])->forget($cacheKey);
 
             return;
         }
 
-        Cache::forget( $cacheKey );
+        Cache::forget($cacheKey);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,25 +6,21 @@
  * This file contains global helper functions for the Rbac package.
  * Add custom helper functions below.
  *
- * @package    ArtisanPack_UI
- * @subpackage Rbac
  *
  * @since      1.0.0
  */
 
 use ArtisanPackUI\Rbac\Rbac;
 
-if ( ! function_exists( 'rbac' ) ) {
+if (! function_exists('rbac')) {
     /**
      * Get the Rbac instance.
      *
      * @since 1.0.0
-     *
-     * @return Rbac
      */
     function rbac(): Rbac
     {
-        return app( 'rbac' );
+        return app('rbac');
     }
 }
 

--- a/tests/Feature/BladeDirectivesTest.php
+++ b/tests/Feature/BladeDirectivesTest.php
@@ -1,49 +1,49 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 use Tests\Models\TestUser;
 
-it( 'renders the @role block when the user has the role', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $user->roles()->attach( Role::create( [ 'name' => 'admin' ] ) );
-    $this->actingAs( $user );
+it('renders the @role block when the user has the role', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $user->roles()->attach(Role::create(['name' => 'admin']));
+    $this->actingAs($user);
 
-    $rendered = view()->file( __DIR__ . '/../views/role-directive.blade.php' )->render();
+    $rendered = view()->file(__DIR__.'/../views/role-directive.blade.php')->render();
 
-    expect( $rendered )->toContain( 'User is an admin' );
-    expect( $rendered )->not->toContain( 'User is a moderator' );
-} );
+    expect($rendered)->toContain('User is an admin');
+    expect($rendered)->not->toContain('User is a moderator');
+});
 
-it( 'renders nothing for unauthenticated users in @role blocks', function (): void {
-    Role::create( [ 'name' => 'admin' ] );
+it('renders nothing for unauthenticated users in @role blocks', function (): void {
+    Role::create(['name' => 'admin']);
 
-    $rendered = view()->file( __DIR__ . '/../views/role-directive.blade.php' )->render();
+    $rendered = view()->file(__DIR__.'/../views/role-directive.blade.php')->render();
 
-    expect( $rendered )->not->toContain( 'User is an admin' );
-    expect( $rendered )->not->toContain( 'User is a moderator' );
-} );
+    expect($rendered)->not->toContain('User is an admin');
+    expect($rendered)->not->toContain('User is a moderator');
+});
 
-it( 'renders the @permission block when the user has the permission', function (): void {
-    $user       = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role       = Role::create( [ 'name' => 'editor' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $role->permissions()->attach( $permission );
-    $user->roles()->attach( $role );
-    $this->actingAs( $user );
+it('renders the @permission block when the user has the permission', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'editor']);
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $role->permissions()->attach($permission);
+    $user->roles()->attach($role);
+    $this->actingAs($user);
 
-    $rendered = view()->file( __DIR__ . '/../views/permission-directive.blade.php' )->render();
+    $rendered = view()->file(__DIR__.'/../views/permission-directive.blade.php')->render();
 
-    expect( $rendered )->toContain( 'User can edit articles' );
-    expect( $rendered )->not->toContain( 'User can delete articles' );
-} );
+    expect($rendered)->toContain('User can edit articles');
+    expect($rendered)->not->toContain('User can delete articles');
+});
 
-it( 'renders nothing for unauthenticated users in @permission blocks', function (): void {
-    Permission::create( [ 'name' => 'edit-articles' ] );
+it('renders nothing for unauthenticated users in @permission blocks', function (): void {
+    Permission::create(['name' => 'edit-articles']);
 
-    $rendered = view()->file( __DIR__ . '/../views/permission-directive.blade.php' )->render();
+    $rendered = view()->file(__DIR__.'/../views/permission-directive.blade.php')->render();
 
-    expect( $rendered )->not->toContain( 'User can edit articles' );
-} );
+    expect($rendered)->not->toContain('User can edit articles');
+});

--- a/tests/Feature/Concerns/HasPermissionsTest.php
+++ b/tests/Feature/Concerns/HasPermissionsTest.php
@@ -1,70 +1,70 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 use Tests\Models\TestUser;
 
-it( 'returns true for permissions held through a directly-assigned role', function (): void {
-    $user       = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role       = Role::create( [ 'name' => 'editor' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $role->permissions()->attach( $permission );
-    $user->roles()->attach( $role );
+it('returns true for permissions held through a directly-assigned role', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'editor']);
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $role->permissions()->attach($permission);
+    $user->roles()->attach($role);
 
-    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeTrue();
-    expect( $user->hasPermissionTo( 'delete-articles' ) )->toBeFalse();
-} );
+    expect($user->hasPermissionTo('edit-articles'))->toBeTrue();
+    expect($user->hasPermissionTo('delete-articles'))->toBeFalse();
+});
 
-it( 'aliases hasPermission to hasPermissionTo', function (): void {
-    $user       = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role       = Role::create( [ 'name' => 'editor' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $role->permissions()->attach( $permission );
-    $user->roles()->attach( $role );
+it('aliases hasPermission to hasPermissionTo', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'editor']);
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $role->permissions()->attach($permission);
+    $user->roles()->attach($role);
 
-    expect( $user->hasPermission( 'edit-articles' ) )->toBeTrue();
-} );
+    expect($user->hasPermission('edit-articles'))->toBeTrue();
+});
 
-it( 'walks the role hierarchy when resolving permissions', function (): void {
-    $user        = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $admin       = Role::create( [ 'name' => 'admin' ] );
-    $editor      = Role::create( [ 'name' => 'editor', 'parent_id' => $admin->id ] );
-    $permission  = Permission::create( [ 'name' => 'edit-articles' ] );
-    $admin->permissions()->attach( $permission );
-    $user->roles()->attach( $editor );
+it('walks the role hierarchy when resolving permissions', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $admin = Role::create(['name' => 'admin']);
+    $editor = Role::create(['name' => 'editor', 'parent_id' => $admin->id]);
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $admin->permissions()->attach($permission);
+    $user->roles()->attach($editor);
 
-    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeTrue();
-} );
+    expect($user->hasPermissionTo('edit-articles'))->toBeTrue();
+});
 
-it( 'does not loop when role hierarchy contains a cycle', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $a    = Role::create( [ 'name' => 'a' ] );
-    $b    = Role::create( [ 'name' => 'b', 'parent_id' => $a->id ] );
-    $a->update( [ 'parent_id' => $b->id ] );
+it('does not loop when role hierarchy contains a cycle', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $a = Role::create(['name' => 'a']);
+    $b = Role::create(['name' => 'b', 'parent_id' => $a->id]);
+    $a->update(['parent_id' => $b->id]);
 
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $a->permissions()->attach( $permission );
-    $user->roles()->attach( $b );
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $a->permissions()->attach($permission);
+    $user->roles()->attach($b);
 
-    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeTrue();
-    expect( $user->hasPermissionTo( 'unknown' ) )->toBeFalse();
-} );
+    expect($user->hasPermissionTo('edit-articles'))->toBeTrue();
+    expect($user->hasPermissionTo('unknown'))->toBeFalse();
+});
 
-it( 'flushes the permission cache on demand', function (): void {
-    $user       = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role       = Role::create( [ 'name' => 'editor' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $role->permissions()->attach( $permission );
-    $user->roles()->attach( $role );
-    $user->load( 'roles.permissions' );
+it('flushes the permission cache on demand', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'editor']);
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $role->permissions()->attach($permission);
+    $user->roles()->attach($role);
+    $user->load('roles.permissions');
 
-    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeTrue();
+    expect($user->hasPermissionTo('edit-articles'))->toBeTrue();
 
-    $role->permissions()->detach( $permission );
-    $user->load( 'roles.permissions' );
+    $role->permissions()->detach($permission);
+    $user->load('roles.permissions');
     $user->flushPermissionCache();
 
-    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeFalse();
-} );
+    expect($user->hasPermissionTo('edit-articles'))->toBeFalse();
+});

--- a/tests/Feature/Concerns/HasRolesTest.php
+++ b/tests/Feature/Concerns/HasRolesTest.php
@@ -1,102 +1,103 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Role;
+use Illuminate\Support\Facades\Event;
 use Tests\Models\TestUser;
 
-it( 'has a roles relationship', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role = Role::create( [ 'name' => 'admin' ] );
+it('has a roles relationship', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'admin']);
 
-    $user->roles()->attach( $role );
+    $user->roles()->attach($role);
 
-    expect( $user->roles )->toHaveCount( 1 );
-    expect( $user->roles->first()->name )->toBe( 'admin' );
-} );
+    expect($user->roles)->toHaveCount(1);
+    expect($user->roles->first()->name)->toBe('admin');
+});
 
-it( 'returns true for hasRole when the user has the named role', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $user->roles()->attach( Role::create( [ 'name' => 'admin' ] ) );
+it('returns true for hasRole when the user has the named role', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $user->roles()->attach(Role::create(['name' => 'admin']));
 
-    expect( $user->hasRole( 'admin' ) )->toBeTrue();
-    expect( $user->hasRole( 'moderator' ) )->toBeFalse();
-} );
+    expect($user->hasRole('admin'))->toBeTrue();
+    expect($user->hasRole('moderator'))->toBeFalse();
+});
 
-it( 'accepts a Role instance for hasRole', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role = Role::create( [ 'name' => 'admin' ] );
-    $user->roles()->attach( $role );
+it('accepts a Role instance for hasRole', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'admin']);
+    $user->roles()->attach($role);
 
-    expect( $user->hasRole( $role ) )->toBeTrue();
-    expect( $user->hasRole( Role::create( [ 'name' => 'other' ] ) ) )->toBeFalse();
-} );
+    expect($user->hasRole($role))->toBeTrue();
+    expect($user->hasRole(Role::create(['name' => 'other'])))->toBeFalse();
+});
 
-it( 'accepts a Collection for hasRole and returns true when any match', function (): void {
-    $user  = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $admin = Role::create( [ 'name' => 'admin' ] );
-    $mod   = Role::create( [ 'name' => 'moderator' ] );
-    $user->roles()->attach( $admin );
+it('accepts a Collection for hasRole and returns true when any match', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $admin = Role::create(['name' => 'admin']);
+    $mod = Role::create(['name' => 'moderator']);
+    $user->roles()->attach($admin);
 
-    expect( $user->hasRole( collect( [ $admin, $mod ] ) ) )->toBeTrue();
-    expect( $user->hasRole( collect( [ $mod ] ) ) )->toBeFalse();
-} );
+    expect($user->hasRole(collect([$admin, $mod])))->toBeTrue();
+    expect($user->hasRole(collect([$mod])))->toBeFalse();
+});
 
-it( 'assigns a role by name', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    Role::create( [ 'name' => 'admin' ] );
+it('assigns a role by name', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    Role::create(['name' => 'admin']);
 
-    $user->assignRole( 'admin' );
+    $user->assignRole('admin');
 
-    expect( $user->fresh()->hasRole( 'admin' ) )->toBeTrue();
-} );
+    expect($user->fresh()->hasRole('admin'))->toBeTrue();
+});
 
-it( 'assigns a role by Role instance', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role = Role::create( [ 'name' => 'admin' ] );
+it('assigns a role by Role instance', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'admin']);
 
-    $user->assignRole( $role );
+    $user->assignRole($role);
 
-    expect( $user->fresh()->hasRole( 'admin' ) )->toBeTrue();
-} );
+    expect($user->fresh()->hasRole('admin'))->toBeTrue();
+});
 
-it( 'is idempotent when assigning the same role twice', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    Role::create( [ 'name' => 'admin' ] );
+it('is idempotent when assigning the same role twice', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    Role::create(['name' => 'admin']);
 
-    $user->assignRole( 'admin' );
-    $user->assignRole( 'admin' );
+    $user->assignRole('admin');
+    $user->assignRole('admin');
 
-    expect( $user->fresh()->roles )->toHaveCount( 1 );
-} );
+    expect($user->fresh()->roles)->toHaveCount(1);
+});
 
-it( 'silently no-ops when assigning an unknown role name', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
+it('silently no-ops when assigning an unknown role name', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
 
-    $user->assignRole( 'ghost' );
+    $user->assignRole('ghost');
 
-    expect( $user->fresh()->roles )->toHaveCount( 0 );
-} );
+    expect($user->fresh()->roles)->toHaveCount(0);
+});
 
-it( 'removes a role', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    Role::create( [ 'name' => 'admin' ] );
-    $user->assignRole( 'admin' );
+it('removes a role', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    Role::create(['name' => 'admin']);
+    $user->assignRole('admin');
 
-    $user->removeRole( 'admin' );
+    $user->removeRole('admin');
 
-    expect( $user->fresh()->hasRole( 'admin' ) )->toBeFalse();
-} );
+    expect($user->fresh()->hasRole('admin'))->toBeFalse();
+});
 
-it( 'dispatches events when roles are assigned and removed', function (): void {
-    Illuminate\Support\Facades\Event::fake();
+it('dispatches events when roles are assigned and removed', function (): void {
+    Event::fake();
 
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    Role::create( [ 'name' => 'admin' ] );
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    Role::create(['name' => 'admin']);
 
-    $user->assignRole( 'admin' );
-    $user->removeRole( 'admin' );
+    $user->assignRole('admin');
+    $user->removeRole('admin');
 
-    Illuminate\Support\Facades\Event::assertDispatched( 'rbac.user.role_assigned' );
-    Illuminate\Support\Facades\Event::assertDispatched( 'rbac.user.role_removed' );
-} );
+    Event::assertDispatched('rbac.user.role_assigned');
+    Event::assertDispatched('rbac.user.role_removed');
+});

--- a/tests/Feature/ConfigurableModelBindingTest.php
+++ b/tests/Feature/ConfigurableModelBindingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
@@ -9,47 +9,47 @@ use Tests\Models\CustomPermission;
 use Tests\Models\CustomRole;
 use Tests\Models\TestUser;
 
-it( 'role:create command honors a configured custom role model', function (): void {
-    Config::set( 'artisanpack.rbac.models.role', CustomRole::class );
+it('role:create command honors a configured custom role model', function (): void {
+    Config::set('artisanpack.rbac.models.role', CustomRole::class);
 
-    $this->artisan( 'role:create', [ 'name' => 'admin' ] )->assertSuccessful();
+    $this->artisan('role:create', ['name' => 'admin'])->assertSuccessful();
 
-    $role = CustomRole::where( 'name', 'admin' )->first();
-    expect( $role )->toBeInstanceOf( CustomRole::class );
-    expect( $role->customLabel() )->toBe( 'custom:admin' );
-} );
+    $role = CustomRole::where('name', 'admin')->first();
+    expect($role)->toBeInstanceOf(CustomRole::class);
+    expect($role->customLabel())->toBe('custom:admin');
+});
 
-it( 'permission:create command honors a configured custom permission model', function (): void {
-    Config::set( 'artisanpack.rbac.models.permission', CustomPermission::class );
+it('permission:create command honors a configured custom permission model', function (): void {
+    Config::set('artisanpack.rbac.models.permission', CustomPermission::class);
 
-    $this->artisan( 'permission:create', [ 'name' => 'edit-articles' ] )->assertSuccessful();
+    $this->artisan('permission:create', ['name' => 'edit-articles'])->assertSuccessful();
 
-    $permission = CustomPermission::where( 'name', 'edit-articles' )->first();
-    expect( $permission )->toBeInstanceOf( CustomPermission::class );
-} );
+    $permission = CustomPermission::where('name', 'edit-articles')->first();
+    expect($permission)->toBeInstanceOf(CustomPermission::class);
+});
 
-it( 'HasRoles trait resolves role lookups against the configured model', function (): void {
-    Config::set( 'artisanpack.rbac.models.role', CustomRole::class );
+it('HasRoles trait resolves role lookups against the configured model', function (): void {
+    Config::set('artisanpack.rbac.models.role', CustomRole::class);
 
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    CustomRole::create( [ 'name' => 'admin' ] );
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    CustomRole::create(['name' => 'admin']);
 
-    $user->assignRole( 'admin' );
+    $user->assignRole('admin');
 
     $resolved = $user->fresh();
-    $resolved->load( 'roles' );
+    $resolved->load('roles');
 
-    expect( $resolved->hasRole( 'admin' ) )->toBeTrue();
-    expect( $resolved->roles->first() )->toBeInstanceOf( CustomRole::class );
-} );
+    expect($resolved->hasRole('admin'))->toBeTrue();
+    expect($resolved->roles->first())->toBeInstanceOf(CustomRole::class);
+});
 
-it( 'falls back to base models when no override is configured', function (): void {
-    expect( Config::get( 'artisanpack.rbac.models.role' ) )->toBe( Role::class );
-    expect( Config::get( 'artisanpack.rbac.models.permission' ) )->toBe( Permission::class );
+it('falls back to base models when no override is configured', function (): void {
+    expect(Config::get('artisanpack.rbac.models.role'))->toBe(Role::class);
+    expect(Config::get('artisanpack.rbac.models.permission'))->toBe(Permission::class);
 
-    $role       = Role::create( [ 'name' => 'admin' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
+    $role = Role::create(['name' => 'admin']);
+    $permission = Permission::create(['name' => 'edit-articles']);
 
-    expect( $role )->toBeInstanceOf( Role::class );
-    expect( $permission )->toBeInstanceOf( Permission::class );
-} );
+    expect($role)->toBeInstanceOf(Role::class);
+    expect($permission)->toBeInstanceOf(Permission::class);
+});

--- a/tests/Feature/Console/AssignRoleTest.php
+++ b/tests/Feature/Console/AssignRoleTest.php
@@ -1,56 +1,56 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Role;
 use Tests\Models\TestUser;
 
-it( 'assigns a role to a user by id', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    Role::create( [ 'name' => 'admin' ] );
+it('assigns a role to a user by id', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    Role::create(['name' => 'admin']);
 
-    $this->artisan( 'user:assign-role', [ 'user' => (string) $user->id, 'role' => 'admin' ] )
+    $this->artisan('user:assign-role', ['user' => (string) $user->id, 'role' => 'admin'])
         ->assertSuccessful();
 
-    expect( $user->fresh()->hasRole( 'admin' ) )->toBeTrue();
-} );
+    expect($user->fresh()->hasRole('admin'))->toBeTrue();
+});
 
-it( 'assigns a role to a user by email', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    Role::create( [ 'name' => 'admin' ] );
+it('assigns a role to a user by email', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    Role::create(['name' => 'admin']);
 
-    $this->artisan( 'user:assign-role', [ 'user' => 'test@example.com', 'role' => 'admin' ] )
+    $this->artisan('user:assign-role', ['user' => 'test@example.com', 'role' => 'admin'])
         ->assertSuccessful();
 
-    expect( $user->fresh()->hasRole( 'admin' ) )->toBeTrue();
-} );
+    expect($user->fresh()->hasRole('admin'))->toBeTrue();
+});
 
-it( 'is idempotent when assigning the same role twice', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    Role::create( [ 'name' => 'admin' ] );
+it('is idempotent when assigning the same role twice', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    Role::create(['name' => 'admin']);
 
-    $this->artisan( 'user:assign-role', [ 'user' => (string) $user->id, 'role' => 'admin' ] )
+    $this->artisan('user:assign-role', ['user' => (string) $user->id, 'role' => 'admin'])
         ->assertSuccessful();
-    $this->artisan( 'user:assign-role', [ 'user' => (string) $user->id, 'role' => 'admin' ] )
+    $this->artisan('user:assign-role', ['user' => (string) $user->id, 'role' => 'admin'])
         ->assertSuccessful();
 
     $fresh = $user->fresh();
-    $fresh->load( 'roles' );
-    expect( $fresh->roles )->toHaveCount( 1 );
-} );
+    $fresh->load('roles');
+    expect($fresh->roles)->toHaveCount(1);
+});
 
-it( 'fails when the user does not exist', function (): void {
-    Role::create( [ 'name' => 'admin' ] );
+it('fails when the user does not exist', function (): void {
+    Role::create(['name' => 'admin']);
 
-    $this->artisan( 'user:assign-role', [ 'user' => '999', 'role' => 'admin' ] )
+    $this->artisan('user:assign-role', ['user' => '999', 'role' => 'admin'])
         ->assertFailed()
-        ->expectsOutputToContain( 'User not found.' );
-} );
+        ->expectsOutputToContain('User not found.');
+});
 
-it( 'fails when the role does not exist', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
+it('fails when the role does not exist', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
 
-    $this->artisan( 'user:assign-role', [ 'user' => (string) $user->id, 'role' => 'ghost' ] )
+    $this->artisan('user:assign-role', ['user' => (string) $user->id, 'role' => 'ghost'])
         ->assertFailed()
-        ->expectsOutputToContain( 'Role not found.' );
-} );
+        ->expectsOutputToContain('Role not found.');
+});

--- a/tests/Feature/Console/CreatePermissionTest.php
+++ b/tests/Feature/Console/CreatePermissionTest.php
@@ -16,3 +16,17 @@ it('stores the description option on the permission', function (): void {
 
     $this->assertDatabaseHas('permissions', ['name' => 'publish', 'description' => 'Publish articles']);
 });
+
+it('auto-derives the slug from the name when --slug is not supplied', function (): void {
+    $this->artisan('permission:create', ['name' => 'Edit Articles'])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('permissions', ['name' => 'Edit Articles', 'slug' => 'edit-articles']);
+});
+
+it('accepts a custom --slug option', function (): void {
+    $this->artisan('permission:create', ['name' => 'publish', '--slug' => 'pages.publish'])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('permissions', ['name' => 'publish', 'slug' => 'pages.publish']);
+});

--- a/tests/Feature/Console/CreatePermissionTest.php
+++ b/tests/Feature/Console/CreatePermissionTest.php
@@ -1,18 +1,18 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
-it( 'creates a permission via the permission:create command', function (): void {
-    $this->artisan( 'permission:create', [ 'name' => 'edit-articles' ] )
+it('creates a permission via the permission:create command', function (): void {
+    $this->artisan('permission:create', ['name' => 'edit-articles'])
         ->assertSuccessful()
-        ->expectsOutputToContain( 'Permission `edit-articles` created successfully.' );
+        ->expectsOutputToContain('Permission `edit-articles` created successfully.');
 
-    $this->assertDatabaseHas( 'permissions', [ 'name' => 'edit-articles' ] );
-} );
+    $this->assertDatabaseHas('permissions', ['name' => 'edit-articles']);
+});
 
-it( 'stores the description option on the permission', function (): void {
-    $this->artisan( 'permission:create', [ 'name' => 'publish', '--description' => 'Publish articles' ] )
+it('stores the description option on the permission', function (): void {
+    $this->artisan('permission:create', ['name' => 'publish', '--description' => 'Publish articles'])
         ->assertSuccessful();
 
-    $this->assertDatabaseHas( 'permissions', [ 'name' => 'publish', 'description' => 'Publish articles' ] );
-} );
+    $this->assertDatabaseHas('permissions', ['name' => 'publish', 'description' => 'Publish articles']);
+});

--- a/tests/Feature/Console/CreateRoleTest.php
+++ b/tests/Feature/Console/CreateRoleTest.php
@@ -16,3 +16,17 @@ it('stores the description option on the role', function (): void {
 
     $this->assertDatabaseHas('roles', ['name' => 'editor', 'description' => 'Editor role']);
 });
+
+it('auto-derives the slug from the name when --slug is not supplied', function (): void {
+    $this->artisan('role:create', ['name' => 'Site Owner'])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('roles', ['name' => 'Site Owner', 'slug' => 'site-owner']);
+});
+
+it('accepts a custom --slug option', function (): void {
+    $this->artisan('role:create', ['name' => 'Site Owner', '--slug' => 'owner'])
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('roles', ['name' => 'Site Owner', 'slug' => 'owner']);
+});

--- a/tests/Feature/Console/CreateRoleTest.php
+++ b/tests/Feature/Console/CreateRoleTest.php
@@ -1,18 +1,18 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
-it( 'creates a role via the role:create command', function (): void {
-    $this->artisan( 'role:create', [ 'name' => 'admin' ] )
+it('creates a role via the role:create command', function (): void {
+    $this->artisan('role:create', ['name' => 'admin'])
         ->assertSuccessful()
-        ->expectsOutputToContain( 'Role `admin` created successfully.' );
+        ->expectsOutputToContain('Role `admin` created successfully.');
 
-    $this->assertDatabaseHas( 'roles', [ 'name' => 'admin' ] );
-} );
+    $this->assertDatabaseHas('roles', ['name' => 'admin']);
+});
 
-it( 'stores the description option on the role', function (): void {
-    $this->artisan( 'role:create', [ 'name' => 'editor', '--description' => 'Editor role' ] )
+it('stores the description option on the role', function (): void {
+    $this->artisan('role:create', ['name' => 'editor', '--description' => 'Editor role'])
         ->assertSuccessful();
 
-    $this->assertDatabaseHas( 'roles', [ 'name' => 'editor', 'description' => 'Editor role' ] );
-} );
+    $this->assertDatabaseHas('roles', ['name' => 'editor', 'description' => 'Editor role']);
+});

--- a/tests/Feature/Console/RevokeRoleTest.php
+++ b/tests/Feature/Console/RevokeRoleTest.php
@@ -1,31 +1,31 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Role;
 use Tests\Models\TestUser;
 
-it( 'revokes a role from a user', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role = Role::create( [ 'name' => 'admin' ] );
-    $user->roles()->attach( $role );
+it('revokes a role from a user', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'admin']);
+    $user->roles()->attach($role);
 
-    $this->artisan( 'user:revoke-role', [ 'user' => (string) $user->id, 'role' => 'admin' ] )
+    $this->artisan('user:revoke-role', ['user' => (string) $user->id, 'role' => 'admin'])
         ->assertSuccessful();
 
-    expect( $user->fresh()->hasRole( 'admin' ) )->toBeFalse();
-} );
+    expect($user->fresh()->hasRole('admin'))->toBeFalse();
+});
 
-it( 'fails when the user does not exist', function (): void {
-    Role::create( [ 'name' => 'admin' ] );
+it('fails when the user does not exist', function (): void {
+    Role::create(['name' => 'admin']);
 
-    $this->artisan( 'user:revoke-role', [ 'user' => '999', 'role' => 'admin' ] )
+    $this->artisan('user:revoke-role', ['user' => '999', 'role' => 'admin'])
         ->assertFailed();
-} );
+});
 
-it( 'fails when the role does not exist', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
+it('fails when the role does not exist', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
 
-    $this->artisan( 'user:revoke-role', [ 'user' => (string) $user->id, 'role' => 'ghost' ] )
+    $this->artisan('user:revoke-role', ['user' => (string) $user->id, 'role' => 'ghost'])
         ->assertFailed();
-} );
+});

--- a/tests/Feature/GateIntegrationTest.php
+++ b/tests/Feature/GateIntegrationTest.php
@@ -1,61 +1,61 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 use Illuminate\Support\Facades\Gate;
 use Tests\Models\TestUser;
 
-it( 'resolves $user->can() through registered RBAC permissions', function (): void {
-    $user       = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role       = Role::create( [ 'name' => 'editor' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $role->permissions()->attach( $permission );
-    $user->roles()->attach( $role );
+it('resolves $user->can() through registered RBAC permissions', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'editor']);
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $role->permissions()->attach($permission);
+    $user->roles()->attach($role);
 
-    expect( $user->can( 'edit-articles' ) )->toBeTrue();
-    expect( $user->can( 'delete-articles' ) )->toBeFalse();
-} );
+    expect($user->can('edit-articles'))->toBeTrue();
+    expect($user->can('delete-articles'))->toBeFalse();
+});
 
-it( 'resolves Gate::allows() through registered RBAC permissions', function (): void {
-    $user       = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role       = Role::create( [ 'name' => 'editor' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $role->permissions()->attach( $permission );
-    $user->roles()->attach( $role );
+it('resolves Gate::allows() through registered RBAC permissions', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'editor']);
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $role->permissions()->attach($permission);
+    $user->roles()->attach($role);
 
-    $this->actingAs( $user );
+    $this->actingAs($user);
 
-    expect( Gate::allows( 'edit-articles' ) )->toBeTrue();
-    expect( Gate::denies( 'delete-articles' ) )->toBeTrue();
-} );
+    expect(Gate::allows('edit-articles'))->toBeTrue();
+    expect(Gate::denies('delete-articles'))->toBeTrue();
+});
 
-it( 'falls back to standard Gate behavior for non-RBAC abilities', function (): void {
-    Gate::define( 'view-dashboard', fn ( $user ) => true );
+it('falls back to standard Gate behavior for non-RBAC abilities', function (): void {
+    Gate::define('view-dashboard', fn ($user) => true);
 
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
 
-    expect( $user->can( 'view-dashboard' ) )->toBeTrue();
-} );
+    expect($user->can('view-dashboard'))->toBeTrue();
+});
 
-it( 'denies non-RBAC abilities with no defined Gate', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
+it('denies non-RBAC abilities with no defined Gate', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
 
-    expect( $user->can( 'undefined-ability' ) )->toBeFalse();
-} );
+    expect($user->can('undefined-ability'))->toBeFalse();
+});
 
-it( 'invalidates the permission-name cache when permissions change', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role = Role::create( [ 'name' => 'editor' ] );
-    $user->roles()->attach( $role );
+it('invalidates the permission-name cache when permissions change', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'editor']);
+    $user->roles()->attach($role);
 
-    expect( $user->can( 'publish' ) )->toBeFalse();
+    expect($user->can('publish'))->toBeFalse();
 
-    $permission = Permission::create( [ 'name' => 'publish' ] );
-    $role->permissions()->attach( $permission );
-    $user->load( 'roles.permissions' );
+    $permission = Permission::create(['name' => 'publish']);
+    $role->permissions()->attach($permission);
+    $user->load('roles.permissions');
     $user->flushPermissionCache();
 
-    expect( $user->can( 'publish' ) )->toBeTrue();
-} );
+    expect($user->can('publish'))->toBeTrue();
+});

--- a/tests/Feature/Http/CheckPermissionMiddlewareTest.php
+++ b/tests/Feature/Http/CheckPermissionMiddlewareTest.php
@@ -1,57 +1,57 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 use Illuminate\Support\Facades\Route;
 use Tests\Models\TestUser;
 
-beforeEach( function (): void {
-    Route::get( '/protected-route', fn () => 'Success' )->middleware( 'permission:edit-articles' );
-    Route::get( '/multi-permission', fn () => 'Success' )->middleware( 'permission:edit-articles,delete-articles' );
-} );
+beforeEach(function (): void {
+    Route::get('/protected-route', fn () => 'Success')->middleware('permission:edit-articles');
+    Route::get('/multi-permission', fn () => 'Success')->middleware('permission:edit-articles,delete-articles');
+});
 
-it( 'returns 401 for unauthenticated users', function (): void {
-    $this->get( '/protected-route' )->assertStatus( 401 );
-} );
+it('returns 401 for unauthenticated users', function (): void {
+    $this->get('/protected-route')->assertStatus(401);
+});
 
-it( 'returns 403 when an authenticated user lacks the permission', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
+it('returns 403 when an authenticated user lacks the permission', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
 
-    $this->actingAs( $user )
-        ->get( '/protected-route' )
-        ->assertStatus( 403 );
-} );
+    $this->actingAs($user)
+        ->get('/protected-route')
+        ->assertStatus(403);
+});
 
-it( 'returns 200 when the user has the required permission', function (): void {
-    $user       = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role       = Role::create( [ 'name' => 'editor' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $role->permissions()->attach( $permission );
-    $user->roles()->attach( $role );
+it('returns 200 when the user has the required permission', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'editor']);
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $role->permissions()->attach($permission);
+    $user->roles()->attach($role);
 
-    $this->actingAs( $user )
-        ->get( '/protected-route' )
-        ->assertStatus( 200 );
-} );
+    $this->actingAs($user)
+        ->get('/protected-route')
+        ->assertStatus(200);
+});
 
-it( 'allows access when the user has any of multiple permissions', function (): void {
-    $user       = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
-    $role       = Role::create( [ 'name' => 'reviewer' ] );
-    $permission = Permission::create( [ 'name' => 'delete-articles' ] );
-    $role->permissions()->attach( $permission );
-    $user->roles()->attach( $role );
+it('allows access when the user has any of multiple permissions', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $role = Role::create(['name' => 'reviewer']);
+    $permission = Permission::create(['name' => 'delete-articles']);
+    $role->permissions()->attach($permission);
+    $user->roles()->attach($role);
 
-    $this->actingAs( $user )
-        ->get( '/multi-permission' )
-        ->assertStatus( 200 );
-} );
+    $this->actingAs($user)
+        ->get('/multi-permission')
+        ->assertStatus(200);
+});
 
-it( 'denies access when the user has none of the listed permissions', function (): void {
-    $user = TestUser::create( [ 'name' => 'Test', 'email' => 'test@example.com' ] );
+it('denies access when the user has none of the listed permissions', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
 
-    $this->actingAs( $user )
-        ->get( '/multi-permission' )
-        ->assertStatus( 403 );
-} );
+    $this->actingAs($user)
+        ->get('/multi-permission')
+        ->assertStatus(403);
+});

--- a/tests/Feature/Models/PermissionTest.php
+++ b/tests/Feature/Models/PermissionTest.php
@@ -1,34 +1,34 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 
-it( 'creates a permission', function (): void {
-    $permission = Permission::create( [ 'name' => 'edit-articles', 'description' => 'Edit articles' ] );
+it('creates a permission', function (): void {
+    $permission = Permission::create(['name' => 'edit-articles', 'description' => 'Edit articles']);
 
-    expect( $permission->name )->toBe( 'edit-articles' );
-    $this->assertDatabaseHas( 'permissions', [ 'name' => 'edit-articles' ] );
-} );
+    expect($permission->name)->toBe('edit-articles');
+    $this->assertDatabaseHas('permissions', ['name' => 'edit-articles']);
+});
 
-it( 'belongs to many roles', function (): void {
-    $permission = Permission::create( [ 'name' => 'publish' ] );
-    $admin      = Role::create( [ 'name' => 'admin' ] );
-    $editor     = Role::create( [ 'name' => 'editor' ] );
+it('belongs to many roles', function (): void {
+    $permission = Permission::create(['name' => 'publish']);
+    $admin = Role::create(['name' => 'admin']);
+    $editor = Role::create(['name' => 'editor']);
 
-    $permission->roles()->attach( [ $admin->id, $editor->id ] );
-    $permission->load( 'roles' );
+    $permission->roles()->attach([$admin->id, $editor->id]);
+    $permission->load('roles');
 
-    expect( $permission->roles )->toHaveCount( 2 );
-} );
+    expect($permission->roles)->toHaveCount(2);
+});
 
-it( 'detaches roles when a permission is deleted', function (): void {
-    $permission = Permission::create( [ 'name' => 'publish' ] );
-    $role       = Role::create( [ 'name' => 'admin' ] );
-    $permission->roles()->attach( $role );
+it('detaches roles when a permission is deleted', function (): void {
+    $permission = Permission::create(['name' => 'publish']);
+    $role = Role::create(['name' => 'admin']);
+    $permission->roles()->attach($role);
 
     $permission->delete();
 
-    $this->assertDatabaseMissing( 'permission_role', [ 'permission_id' => $permission->id ] );
-} );
+    $this->assertDatabaseMissing('permission_role', ['permission_id' => $permission->id]);
+});

--- a/tests/Feature/Models/RoleTest.php
+++ b/tests/Feature/Models/RoleTest.php
@@ -1,54 +1,54 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 
-it( 'creates a role', function (): void {
-    $role = Role::create( [ 'name' => 'admin', 'description' => 'Administrator' ] );
+it('creates a role', function (): void {
+    $role = Role::create(['name' => 'admin', 'description' => 'Administrator']);
 
-    expect( $role->name )->toBe( 'admin' );
-    expect( $role->description )->toBe( 'Administrator' );
-    $this->assertDatabaseHas( 'roles', [ 'name' => 'admin' ] );
-} );
+    expect($role->name)->toBe('admin');
+    expect($role->description)->toBe('Administrator');
+    $this->assertDatabaseHas('roles', ['name' => 'admin']);
+});
 
-it( 'attaches permissions to a role', function (): void {
-    $role       = Role::create( [ 'name' => 'editor' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
+it('attaches permissions to a role', function (): void {
+    $role = Role::create(['name' => 'editor']);
+    $permission = Permission::create(['name' => 'edit-articles']);
 
-    $role->permissions()->attach( $permission );
-    $role->load( 'permissions' );
+    $role->permissions()->attach($permission);
+    $role->load('permissions');
 
-    expect( $role->permissions )->toHaveCount( 1 );
-    expect( $role->permissions->first()->name )->toBe( 'edit-articles' );
-} );
+    expect($role->permissions)->toHaveCount(1);
+    expect($role->permissions->first()->name)->toBe('edit-articles');
+});
 
-it( 'supports parent/child role hierarchy', function (): void {
-    $admin  = Role::create( [ 'name' => 'admin' ] );
-    $editor = Role::create( [ 'name' => 'editor', 'parent_id' => $admin->id ] );
-    $editor->load( 'parent' );
-    $admin->load( 'children' );
+it('supports parent/child role hierarchy', function (): void {
+    $admin = Role::create(['name' => 'admin']);
+    $editor = Role::create(['name' => 'editor', 'parent_id' => $admin->id]);
+    $editor->load('parent');
+    $admin->load('children');
 
-    expect( $editor->parent->id )->toBe( $admin->id );
-    expect( $admin->children->first()->id )->toBe( $editor->id );
-} );
+    expect($editor->parent->id)->toBe($admin->id);
+    expect($admin->children->first()->id)->toBe($editor->id);
+});
 
-it( 'detaches permissions when a role is deleted', function (): void {
-    $role       = Role::create( [ 'name' => 'admin' ] );
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $role->permissions()->attach( $permission );
+it('detaches permissions when a role is deleted', function (): void {
+    $role = Role::create(['name' => 'admin']);
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $role->permissions()->attach($permission);
 
     $role->delete();
 
-    $this->assertDatabaseMissing( 'permission_role', [ 'role_id' => $role->id ] );
-} );
+    $this->assertDatabaseMissing('permission_role', ['role_id' => $role->id]);
+});
 
-it( 'nulls parent_id on children when a parent role is deleted', function (): void {
-    $admin  = Role::create( [ 'name' => 'admin' ] );
-    $editor = Role::create( [ 'name' => 'editor', 'parent_id' => $admin->id ] );
+it('nulls parent_id on children when a parent role is deleted', function (): void {
+    $admin = Role::create(['name' => 'admin']);
+    $editor = Role::create(['name' => 'editor', 'parent_id' => $admin->id]);
 
     $admin->delete();
 
-    expect( $editor->fresh()->parent_id )->toBeNull();
-} );
+    expect($editor->fresh()->parent_id)->toBeNull();
+});

--- a/tests/Feature/Observers/ObserverEventsTest.php
+++ b/tests/Feature/Observers/ObserverEventsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
@@ -11,66 +11,66 @@ use Illuminate\Support\Facades\Event;
  * events that drive the observers, so we instead listen for the package
  * events directly and assert they fired.
  */
-function captureEvent( string $name ): stdClass
+function captureEvent(string $name): stdClass
 {
-    $captured        = new stdClass();
+    $captured = new stdClass;
     $captured->fired = false;
 
-    Event::listen( $name, function () use ( $captured ): void {
+    Event::listen($name, function () use ($captured): void {
         $captured->fired = true;
-    } );
+    });
 
     return $captured;
 }
 
-it( 'dispatches rbac.role.created when a role is created', function (): void {
-    $captured = captureEvent( 'rbac.role.created' );
+it('dispatches rbac.role.created when a role is created', function (): void {
+    $captured = captureEvent('rbac.role.created');
 
-    Role::create( [ 'name' => 'admin' ] );
+    Role::create(['name' => 'admin']);
 
-    expect( $captured->fired )->toBeTrue();
-} );
+    expect($captured->fired)->toBeTrue();
+});
 
-it( 'dispatches rbac.role.updated when a role is updated', function (): void {
-    $role     = Role::create( [ 'name' => 'admin' ] );
-    $captured = captureEvent( 'rbac.role.updated' );
+it('dispatches rbac.role.updated when a role is updated', function (): void {
+    $role = Role::create(['name' => 'admin']);
+    $captured = captureEvent('rbac.role.updated');
 
-    $role->update( [ 'description' => 'Administrator' ] );
+    $role->update(['description' => 'Administrator']);
 
-    expect( $captured->fired )->toBeTrue();
-} );
+    expect($captured->fired)->toBeTrue();
+});
 
-it( 'dispatches rbac.role.deleted when a role is deleted', function (): void {
-    $role     = Role::create( [ 'name' => 'admin' ] );
-    $captured = captureEvent( 'rbac.role.deleted' );
+it('dispatches rbac.role.deleted when a role is deleted', function (): void {
+    $role = Role::create(['name' => 'admin']);
+    $captured = captureEvent('rbac.role.deleted');
 
     $role->delete();
 
-    expect( $captured->fired )->toBeTrue();
-} );
+    expect($captured->fired)->toBeTrue();
+});
 
-it( 'dispatches rbac.permission.created when a permission is created', function (): void {
-    $captured = captureEvent( 'rbac.permission.created' );
+it('dispatches rbac.permission.created when a permission is created', function (): void {
+    $captured = captureEvent('rbac.permission.created');
 
-    Permission::create( [ 'name' => 'edit-articles' ] );
+    Permission::create(['name' => 'edit-articles']);
 
-    expect( $captured->fired )->toBeTrue();
-} );
+    expect($captured->fired)->toBeTrue();
+});
 
-it( 'dispatches rbac.permission.updated when a permission is updated', function (): void {
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $captured   = captureEvent( 'rbac.permission.updated' );
+it('dispatches rbac.permission.updated when a permission is updated', function (): void {
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $captured = captureEvent('rbac.permission.updated');
 
-    $permission->update( [ 'description' => 'Edit articles' ] );
+    $permission->update(['description' => 'Edit articles']);
 
-    expect( $captured->fired )->toBeTrue();
-} );
+    expect($captured->fired)->toBeTrue();
+});
 
-it( 'dispatches rbac.permission.deleted when a permission is deleted', function (): void {
-    $permission = Permission::create( [ 'name' => 'edit-articles' ] );
-    $captured   = captureEvent( 'rbac.permission.deleted' );
+it('dispatches rbac.permission.deleted when a permission is deleted', function (): void {
+    $permission = Permission::create(['name' => 'edit-articles']);
+    $captured = captureEvent('rbac.permission.deleted');
 
     $permission->delete();
 
-    expect( $captured->fired )->toBeTrue();
-} );
+    expect($captured->fired)->toBeTrue();
+});

--- a/tests/Feature/SlugDerivationTest.php
+++ b/tests/Feature/SlugDerivationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\Rbac\Models\Permission;
+use ArtisanPackUI\Rbac\Models\Role;
+use Tests\Models\TestUser;
+
+it('derives slug from name when slug is not provided on Role', function (): void {
+    $role = Role::create(['name' => 'Site Owner']);
+
+    expect($role->slug)->toBe('site-owner');
+});
+
+it('derives slug from name when slug is not provided on Permission', function (): void {
+    $permission = Permission::create(['name' => 'Manage Users']);
+
+    expect($permission->slug)->toBe('manage-users');
+});
+
+it('preserves a slug supplied at creation time on Role', function (): void {
+    $role = Role::create(['name' => 'Site Owner', 'slug' => 'owner']);
+
+    expect($role->slug)->toBe('owner');
+});
+
+it('preserves a slug supplied at creation time on Permission', function (): void {
+    $permission = Permission::create(['name' => 'Manage Users', 'slug' => 'users.manage']);
+
+    expect($permission->slug)->toBe('users.manage');
+});
+
+it('looks up a Role by slug via findBySlug', function (): void {
+    Role::create(['name' => 'Editor', 'slug' => 'editor']);
+
+    $found = Role::findBySlug('editor');
+
+    expect($found)->not->toBeNull()
+        ->and($found->name)->toBe('Editor');
+});
+
+it('looks up a Permission by slug via findBySlug', function (): void {
+    Permission::create(['name' => 'Publish Pages', 'slug' => 'pages.publish']);
+
+    $found = Permission::findBySlug('pages.publish');
+
+    expect($found)->not->toBeNull()
+        ->and($found->name)->toBe('Publish Pages');
+});
+
+it('matches hasRole by slug as well as name', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'slug-role@example.com']);
+    Role::create(['name' => 'Editor', 'slug' => 'editor']);
+
+    $user->assignRole('editor');
+
+    expect($user->hasRole('editor'))->toBeTrue()
+        ->and($user->hasRole('Editor'))->toBeTrue();
+});
+
+it('matches hasPermissionTo by slug as well as name', function (): void {
+    $user = TestUser::create(['name' => 'Test', 'email' => 'slug-perm@example.com']);
+    $role = Role::create(['name' => 'Editor', 'slug' => 'editor']);
+    $permission = Permission::create(['name' => 'Publish Pages', 'slug' => 'pages.publish']);
+
+    $role->permissions()->attach($permission);
+    $user->assignRole('editor');
+
+    expect($user->hasPermissionTo('pages.publish'))->toBeTrue()
+        ->and($user->hasPermissionTo('Publish Pages'))->toBeTrue();
+});

--- a/tests/Feature/SlugDerivationTest.php
+++ b/tests/Feature/SlugDerivationTest.php
@@ -69,3 +69,39 @@ it('matches hasPermissionTo by slug as well as name', function (): void {
     expect($user->hasPermissionTo('pages.publish'))->toBeTrue()
         ->and($user->hasPermissionTo('Publish Pages'))->toBeTrue();
 });
+
+it('rejects a Role save that would collide its name with another row\'s slug', function (): void {
+    Role::create(['name' => 'Editor', 'slug' => 'editor']);
+
+    expect(fn () => Role::create(['name' => 'editor', 'slug' => 'second']))
+        ->toThrow(RuntimeException::class);
+});
+
+it('rejects a Permission save that would collide its slug with another row\'s name', function (): void {
+    Permission::create(['name' => 'Publish Pages', 'slug' => 'pages.publish']);
+
+    expect(fn () => Permission::create(['name' => 'Other', 'slug' => 'Publish Pages']))
+        ->toThrow(RuntimeException::class);
+});
+
+it('allows a Role save where name and slug are equal on the same row', function (): void {
+    // Most common post-auto-derivation case: name === slug on the same
+    // row. The collision guard must allow this.
+    $role = Role::create(['name' => 'editor', 'slug' => 'editor']);
+
+    expect($role->name)->toBe('editor')
+        ->and($role->slug)->toBe('editor');
+});
+
+it('resolves hasRole to the name-matched row when another row has the same string as a slug', function (): void {
+    // Cross-row collision regression: Role A has name='shipper', Role B
+    // has name='Shipping' but slug='shipper'. assignRole('shipper') must
+    // resolve to Role A (name match wins).
+    $a = Role::create(['name' => 'shipper', 'slug' => 'shipper-role']);
+    Role::create(['name' => 'Shipping', 'slug' => 'shipper-2']);
+
+    $user = TestUser::create(['name' => 'Test', 'email' => 'collision@example.com']);
+    $user->assignRole('shipper');
+
+    expect($user->roles->pluck('id')->all())->toBe([$a->id]);
+});

--- a/tests/Models/CustomPermission.php
+++ b/tests/Models/CustomPermission.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace Tests\Models;
 
@@ -12,6 +12,6 @@ class CustomPermission extends Permission
 
     public function customLabel(): string
     {
-        return 'custom:' . $this->name;
+        return 'custom:'.$this->name;
     }
 }

--- a/tests/Models/CustomRole.php
+++ b/tests/Models/CustomRole.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace Tests\Models;
 
@@ -12,6 +12,6 @@ class CustomRole extends Role
 
     public function customLabel(): string
     {
-        return 'custom:' . $this->name;
+        return 'custom:'.$this->name;
     }
 }

--- a/tests/Models/TestUser.php
+++ b/tests/Models/TestUser.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace Tests\Models;
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Tests\TestCase;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -11,9 +13,9 @@
 |
 */
 
-pest()->extend( Tests\TestCase::class )
+pest()->extend(TestCase::class)
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in( 'Feature' );
+    ->in('Feature');
 
 /*
 |--------------------------------------------------------------------------
@@ -26,9 +28,9 @@ pest()->extend( Tests\TestCase::class )
 |
 */
 
-expect()->extend( 'toBeOne', function () {
-    return $this->toBe( 1 );
-} );
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,11 +1,12 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace Tests;
 
 use ArtisanPackUI\Rbac\RbacServiceProvider;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Tests\Models\TestUser;
@@ -34,11 +35,10 @@ abstract class TestCase extends BaseTestCase
     /**
      * Gets package providers.
      *
-     * @param  \Illuminate\Foundation\Application  $app  The application instance.
-     *
+     * @param  Application  $app  The application instance.
      * @return array<int, class-string> Array of service provider class names.
      */
-    protected function getPackageProviders( $app ): array
+    protected function getPackageProviders($app): array
     {
         return [
             RbacServiceProvider::class,
@@ -48,21 +48,21 @@ abstract class TestCase extends BaseTestCase
     /**
      * Defines environment setup.
      *
-     * @param  \Illuminate\Foundation\Application  $app  The application instance.
+     * @param  Application  $app  The application instance.
      */
-    protected function defineEnvironment( $app ): void
+    protected function defineEnvironment($app): void
     {
-        $app['config']->set( 'app.key', 'base64:' . base64_encode( random_bytes( 32 ) ) );
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
 
-        $app['config']->set( 'database.default', 'testbench' );
-        $app['config']->set( 'database.connections.testbench', [
-            'driver'                  => 'sqlite',
-            'database'                => ':memory:',
-            'prefix'                  => '',
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
             'foreign_key_constraints' => true,
-        ] );
+        ]);
 
-        $app['config']->set( 'auth.providers.users.model', TestUser::class );
+        $app['config']->set('auth.providers.users.model', TestUser::class);
     }
 
     /**
@@ -73,12 +73,12 @@ abstract class TestCase extends BaseTestCase
      */
     protected function defineDatabaseMigrations(): void
     {
-        $this->app['db']->connection()->getSchemaBuilder()->create( 'users', function ( Blueprint $table ): void {
-            $table->increments( 'id' );
-            $table->string( 'name' );
-            $table->string( 'email' )->unique();
-            $table->string( 'password' )->nullable();
+        $this->app['db']->connection()->getSchemaBuilder()->create('users', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password')->nullable();
             $table->timestamps();
-        } );
+        });
     }
 }

--- a/tests/Unit/ModelFillableTest.php
+++ b/tests/Unit/ModelFillableTest.php
@@ -1,14 +1,14 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 
-it( 'declares the expected fillable attributes on Role', function (): void {
-    expect( ( new Role() )->getFillable() )->toBe( [ 'name', 'description', 'parent_id' ] );
-} );
+it('declares the expected fillable attributes on Role', function (): void {
+    expect((new Role)->getFillable())->toBe(['name', 'slug', 'description', 'parent_id']);
+});
 
-it( 'declares the expected fillable attributes on Permission', function (): void {
-    expect( ( new Permission() )->getFillable() )->toBe( [ 'name', 'description' ] );
-} );
+it('declares the expected fillable attributes on Permission', function (): void {
+    expect((new Permission)->getFillable())->toBe(['name', 'slug', 'description']);
+});


### PR DESCRIPTION
## Summary

Adds a first-class `slug` column to `roles` and `permissions`, plus slug-aware lookups across `HasRoles`, `HasPermissions`, the Gate cache, and the `role:create` / `permission:create` commands.

This is a prerequisite for the **Wave 4 cms-framework Users-module RBAC migration** (per `plans/07-ecosystem-orchestrator.md` §4). cms-framework's existing `Role` / `Permission` use `name` + `slug`, and every internal caller — `hasRole('admin')`, `hasPermissionTo('pages.publish')`, `permission:pages.publish` route middleware, Gate abilities — keys off the slug. Switching cms-framework to subclass rbac's base would break all of those without slug parity in rbac.

## Changes

**Schema:**
- Add `slug` (unique) to `roles` and `permissions` migrations.

**Models:**
- `slug` added to `$fillable` on both Role and Permission.
- Auto-derive from `name` via `Str::slug()` in `save()` if not provided. Implemented as a `save()` override (rather than `static::saving`) so `Event::fake()` in consumer tests doesn't suppress the derivation.
- `whereSlug()` query scope and `findBySlug()` static helper on both.

**Lookups:**
- `HasRoles::hasRole($string)` and `resolveRoleInstance()` now match against `name` OR `slug`.
- `HasPermissions::hasPermissionTo($string)` matches against `name` OR `slug`.
- `RbacServiceProvider` Gate cache pulls both names AND slugs so `$user->can('pages.publish')` resolves whichever was registered.

**Commands:**
- `role:create` and `permission:create` gain a `--slug=` option. Empty strings are filtered out so `--slug=` doesn't persist an empty slug.

**Tests:**
- 8 new feature tests in `tests/Feature/SlugDerivationTest.php` (derivation, preservation, lookup, slug-aware `hasRole` / `hasPermissionTo`).
- 4 new tests on the create commands covering auto-derivation + the `--slug` option.
- `tests/Unit/ModelFillableTest.php` updated for the new fillable.

**Docs:**
- README updated with the new column, helpers, and `--slug` flag.

## Test plan

- [x] `vendor/bin/pest --compact` — 73 passed / 120 assertions
- [x] `vendor/bin/pint` clean
- [x] CodeRabbit CLI run pre-PR; addressed findings (added `--slug` option + empty-string filter)
- [ ] Reviewer: confirm the `name` OR `slug` matching doesn't introduce ambiguity for installs that have a permission named `foo` and a different permission slugged `foo`. (Practically: with both columns unique and slug auto-derived from name, this would require manually setting one side to collide with the other side of a different row — discouraged but technically allowed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slug support for roles and permissions (auto-derived from name), lookup helpers, and checks accepting name or slug; create commands accept optional --slug.
* **Database**
  * Migrations add unique slug columns for roles and permissions.
* **Documentation**
  * README updated to document slug behavior and expanded command signatures.
* **Tests**
  * Added/expanded tests for slug derivation, lookup, and collision cases; many tests modernized for style.
* **Chores**
  * Codebase formatting and strict-typing/style normalizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->