### PR TITLE
Release prep for v1.0.0

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -1,0 +1,9 @@
+name: Auto-assign milestone
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-milestone:
+    uses: ArtisanPack-UI/.github/.github/workflows/auto-milestone.yml@main

--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   auto-milestone:
-    uses: ArtisanPack-UI/.github/.github/workflows/auto-milestone.yml@main
+    uses: ArtisanPack-UI/.github/.github/workflows/auto-milestone.yml@7329ccfac5f658e9528413eb8a8e3cc5b5a95512 # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
         run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Run PHPCS
-        continue-on-error: true
         run: ./vendor/bin/phpcs src/ database/ tests/ config/
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     name: Lint
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
@@ -27,7 +27,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -48,10 +48,10 @@ jobs:
     name: Test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
@@ -62,7 +62,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*'
   pull_request:
     branches: [main]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    name: Lint
 
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -37,12 +36,12 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
-      - name: Upload vendor directory
-        uses: actions/upload-artifact@v4
-        with:
-          name: vendor
-          path: vendor/
-          retention-days: 1
+      - name: Run PHP-CS-Fixer
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
+
+      - name: Run PHPCS
+        continue-on-error: true
+        run: ./vendor/bin/phpcs src/ database/ tests/ config/
 
   test:
     runs-on: ubuntu-latest
@@ -55,7 +54,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -67,7 +66,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
@@ -76,48 +75,9 @@ jobs:
       - name: Run Unit tests
         env:
           XDEBUG_MODE: off
-        run: php vendor/bin/pest tests/Unit --no-coverage
+        run: vendor/bin/pest tests/Unit --no-coverage
 
       - name: Run Feature tests
         env:
           XDEBUG_MODE: off
-        run: php vendor/bin/pest tests/Feature --no-coverage
-
-  release:
-    needs: test
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    name: Create Release
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Extract release notes from CHANGELOG
-        id: changelog
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Extracting notes for version $VERSION"
-
-          if [ -f "CHANGELOG.md" ]; then
-            # Extract section for this version
-            NOTES=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
-            if [ -z "$NOTES" ]; then
-              NOTES="Release $VERSION. See CHANGELOG.md for details."
-            fi
-          else
-            NOTES="Release $VERSION"
-          fi
-
-          # Save to file for multi-line support
-          echo "$NOTES" > release_notes.txt
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release_notes.txt
-          generate_release_notes: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: vendor/bin/pest tests/Feature --no-coverage

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,39 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    if: false # Temporarily disabled while actively developing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@99ca333651aa9a8becc279065fad21c4ef1c4494 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: false # Temporarily disabled while actively developing
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,46 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: false # Temporarily disabled while actively developing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,18 @@ on:
 
 jobs:
   claude:
-    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' && (
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body, '@claude') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned')
+    ) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,18 +12,21 @@ on:
 
 jobs:
   claude:
-    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' && (
-      (github.event_name == 'issue_comment' &&
-       contains(github.event.comment.body, '@claude') &&
-       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@claude') &&
-       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' &&
-       contains(github.event.review.body, '@claude') &&
-       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && github.event.action == 'assigned')
-    ) }}
+    if: >-
+      ${{
+        vars.ENABLE_CLAUDE_REVIEW == 'true' && (
+          (github.event_name == 'issue_comment' &&
+           contains(github.event.comment.body, '@claude') &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+          (github.event_name == 'pull_request_review_comment' &&
+           contains(github.event.comment.body, '@claude') &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+          (github.event_name == 'pull_request_review' &&
+           contains(github.event.review.body, '@claude') &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+          (github.event_name == 'issues' && github.event.action == 'assigned')
+        )
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,13 +22,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@99ca333651aa9a8becc279065fad21c4ef1c4494 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude:
-    if: false # Temporarily disabled while actively developing
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Test before release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        env:
+          XDEBUG_MODE: off
+        run: vendor/bin/pest --no-coverage
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Create Release
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          echo "Extracting notes for version $VERSION"
+
+          if [ ! -f "CHANGELOG.md" ]; then
+            echo "body=Release v$VERSION" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Extract the section between this version header and the next version header
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) { found=1; next }
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          # Remove leading/trailing blank lines
+          NOTES=$(echo "$NOTES" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')
+
+          if [ -z "$NOTES" ]; then
+            NOTES="Release v$VERSION — see CHANGELOG.md for details."
+          fi
+
+          # Write to file for multi-line support
+          echo "$NOTES" > release_notes.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ steps.version.outputs.version }}
+          body_path: release_notes.txt
+          generate_release_notes: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Packagist
+        if: success()
+        run: |
+          curl -s -X POST \
+            "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
+            -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
+            -H "Content-Type: application/json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           echo "Extracting notes for version $VERSION"
 
           if [ ! -f "CHANGELOG.md" ]; then
-            echo "body=Release v$VERSION" >> $GITHUB_OUTPUT
+            echo "Release v$VERSION" > release_notes.txt
             exit 0
           fi
 
@@ -97,7 +97,7 @@ jobs:
       - name: Update Packagist
         if: success()
         run: |
-          curl -s -X POST \
+          curl --fail-with-body --show-error --retry 3 --retry-delay 2 --max-time 30 -X POST \
             "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
             -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
             -H "Content-Type: application/json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     name: Test before release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
@@ -26,7 +26,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -49,7 +49,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Extract version from tag
         id: version
@@ -86,7 +86,7 @@ jobs:
           echo "$NOTES" > release_notes.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           name: v${{ steps.version.outputs.version }}
           body_path: release_notes.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-18
+
 ### Added
 
 - Initial release of the standalone RBAC package, extracted from `artisanpack-ui/security` 1.x as part of the Security 2.0 package split.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,35 @@
 # ArtisanPack UI RBAC Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ### Added
-- Initial package scaffold from `package-blueprint` (issue #1).
 
+- Initial release of the standalone RBAC package, extracted from `artisanpack-ui/security` 1.x as part of the Security 2.0 package split.
+- `Role` Eloquent model with parent / child hierarchy, name + auto-derived slug, optional description, and collision-detecting `save()`.
+- `Permission` Eloquent model with name + auto-derived slug and collision-detecting `save()`.
+- `HasRoles` user trait: `roles()` relationship, `hasRole()`, `assignRole()`, `removeRole()` helpers; idempotent assignment and removal.
+- `HasPermissions` user trait: `hasPermissionTo()` (recursive resolution through the role hierarchy), `hasPermission()` alias, `flushPermissionCache()` manual invalidation.
+- `permission` route middleware alias (`permission:posts.publish,posts.review`) — accepts one or more permission slugs and aborts 401 / 403 as appropriate.
+- `@role` and `@permission` Blade directives for view-layer permission gating.
+- Gate integration via `Gate::before` so `$user->can('slug')`, `Gate::allows('slug')`, and `@can('slug')` resolve through RBAC permissions while still falling through to standard policies for non-RBAC abilities.
+- Artisan commands: `role:create`, `permission:create`, `user:assign-role`, `user:revoke-role` — idempotent and configurable user lookup fields.
+- Eloquent observers dispatching `rbac.role.{created,updated,deleted}` and `rbac.permission.{created,updated,deleted}` events for downstream auditing.
+- Pivot events `rbac.user.role_assigned` and `rbac.user.role_removed` dispatched directly from the `HasRoles` trait.
+- Migrations for `roles`, `permissions`, `role_user`, and `permission_role` tables.
+- Configurable model bindings (`artisanpack.rbac.models.role/permission`) so downstream packages can extend the base models without forking.
+- Configurable table names, foreign keys, and user lookup fields for legacy schema integration.
+- Permission-name cache backed by Laravel's tagged cache where available, with automatic invalidation on permission CRUD; user-permission cache with configurable TTL.
+- `Rbac` Facade and `rbac()` helper as the public entry point for future API expansion.
 
+### Changed
+
+- (none — initial release)
+
+### Removed
+
+- This package contains the role / permission / Blade directive / Gate integration content previously bundled in `artisanpack-ui/security` 1.x. See the [`artisanpack-ui/security` UPGRADE guide](https://github.com/ArtisanPack-UI/security/blob/main/UPGRADE.md) for migration instructions from 1.x.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ArtisanPack UI
 
-As an open source project, ArtisanPack UI is open to contributions from everyone. You don't need to be a developer to contribute. Whether it's contributing code, writing documentation, testing the CMS or anything in between there's a place for you here to contribute.
+As an open source project, ArtisanPack UI is open to contributions from everyone. You don't need to be a developer to contribute. Whether it's contributing code, writing documentation, testing the packages, or anything in between, there's a place for you here to contribute.
 
 ## Table of Contents
 
@@ -21,8 +21,8 @@ In order to make this a best place for everyone to contribute, there are some ha
 
 * ArtisanPack UI is open to everyone no matter your race, ethnicity, gender, who you love, etc. In order to keep it that way, there's zero tolerance for any racist, misogynistic, xenophobic, bigoted, Zionist, antisemitic (yes, there is a difference), Islamophobic, etc. messages. This includes messages sent to a fellow contributor outside of this repository. In short, don't be a jerk. Failure to comply will result in a ban from the project.
 * Be respectful when communicating with fellow contributors.
-* Respect the decisions made for what to include in the CMS.
-* Work together to create the best possible content management system.
+* Respect the decisions made for what to include in the package.
+* Work together to create the best possible developer toolkit.
 
 ## Ways to Contribute
 
@@ -31,7 +31,7 @@ There are a ton of different ways to contribute to ArtisanPack UI even if you're
 * Write code for ArtisanPack UI core
 * Create plugins to extend ArtisanPack UI
 * Create themes to add designs for ArtisanPack UI
-* Test and report bugs found in the CMS
+* Test and report bugs found in the packages
 * Write documentation
 * Write tutorials and talk about ArtisanPack UI on your blog and/or social media profiles
 * Review pull/merge requests
@@ -44,7 +44,7 @@ There are a ton of different ways to contribute to ArtisanPack UI even if you're
 
 Before contributing, make sure you have:
 - Git installed on your machine
-- PHP 8.1 or higher
+- PHP 8.2 or higher
 - Composer
 - A GitLab, GitHub, or other Git hosting account
 
@@ -465,7 +465,7 @@ Similar to GitHub process:
 
 5. **Submit patch**
    - Create GitLab issue (no account needed via email)
-   - Or email patch to: [your email or link to contribution email]
+   - Or email patch to: support@artisanpackui.dev
    - Describe changes in issue/email
    - Attach `.patch` file
 
@@ -547,7 +547,7 @@ To keep things consistent across the code base, it's important to follow these n
 
 Follow conventional commit format:
 
-```
+```text
 type: Short description
 
 Longer description if needed.
@@ -565,7 +565,7 @@ Closes #123
 - `chore:` - Maintenance tasks
 
 **Examples:**
-```
+```text
 feat: Add dark mode support
 
 Implements dark mode theme with toggle in settings.
@@ -574,7 +574,7 @@ Includes proper color contrast for accessibility.
 Closes #456
 ```
 
-```
+```text
 fix: Resolve navigation menu overlap on mobile
 
 Menu was overlapping content on screens < 768px.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ In order to make this a best place for everyone to contribute, there are some ha
 
 There are a ton of different ways to contribute to ArtisanPack UI even if you're not a developer. Here are some (but not all) of the ways you can contribute to the project:
 
-* Write code for ArtisanPack UI core
-* Create plugins to extend ArtisanPack UI
-* Create themes to add designs for ArtisanPack UI
-* Test and report bugs found in the packages
+* Write code for the package
+* Build integrations or extensions on top of the package
+* Improve the package's tests, docs, and examples
+* Test and report bugs found in the package
 * Write documentation
 * Write tutorials and talk about ArtisanPack UI on your blog and/or social media profiles
 * Review pull/merge requests
@@ -196,7 +196,7 @@ Use this for most MRs. It includes:
 - Description of changes
 - Type of change (Bug fix, Feature, Enhancement, etc.)
 - Testing performed
-- **Accessibility tests** (required for all UI changes)
+- **Tests for the change** (unit and/or feature; required for code changes)
 - Tests added
 - Documentation updates
 - Pre-submission checklist
@@ -278,10 +278,9 @@ Labels that indicate importance:
 ### Area Labels (Where)
 
 Labels that indicate affected code area:
-- `Area::Frontend` - UI/client-side code
-- `Area::Backend` - Server/API code
-- `Area::Design` - Visual design work
-- `Area::Infrastructure` - DevOps/deployment
+- `Area::Core` - Core package logic
+- `Area::Integration` - Integration with Laravel framework / sibling packages
+- `Area::Infrastructure` - DevOps/deployment / CI
 - `Area::Testing` - Test-related work
 
 ### Special Labels
@@ -336,8 +335,8 @@ ArtisanPack UI is primarily hosted on GitLab, but you can contribute from any Gi
 
 2. **Clone your fork**
    ```bash
-   git clone git@gitlab.com:your-username/artisanpack-ui-package.git
-   cd artisanpack-ui-package
+   git clone git@gitlab.com:your-username/package-name.git
+   cd package-name
    ```
 
 3. **Add upstream remote**

--- a/README.md
+++ b/README.md
@@ -279,6 +279,17 @@ composer test
 
 Tests run against an in-memory SQLite database via Orchestra Testbench. The package's own test suite covers role / permission models, traits, middleware, Artisan commands, Blade directives, Gate integration, observers, and the configurable model-binding pattern.
 
+## Sibling packages
+
+| Package | Scope |
+|---|---|
+| [`artisanpack-ui/security-full`](https://github.com/ArtisanPack-UI/security-full) | Meta-package — pulls in the full security suite (all six packages below) in a single require |
+| [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: input sanitization, output escaping, KSES, CSP, security headers |
+| [`artisanpack-ui/security-auth`](https://github.com/ArtisanPack-UI/security-auth) | 2FA, password complexity, account lockout, sessions |
+| [`artisanpack-ui/security-advanced-auth`](https://github.com/ArtisanPack-UI/security-advanced-auth) | WebAuthn, SSO, social login, biometric, device fingerprinting |
+| [`artisanpack-ui/secure-uploads`](https://github.com/ArtisanPack-UI/secure-uploads) | File validation, malware scanning, signed-URL serving |
+| [`artisanpack-ui/security-analytics`](https://github.com/ArtisanPack-UI/security-analytics) | Event logging, anomaly detection, SIEM, dashboards |
+
 ## Contributing
 
 As an open source project, this package is open to contributions from anyone. Please [read through the contributing guidelines](CONTRIBUTING.md) to learn more about how you can contribute.

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Tests run against an in-memory SQLite database via Orchestra Testbench. The pack
 | [`artisanpack-ui/security-advanced-auth`](https://github.com/ArtisanPack-UI/security-advanced-auth) | WebAuthn, SSO, social login, biometric, device fingerprinting |
 | [`artisanpack-ui/secure-uploads`](https://github.com/ArtisanPack-UI/secure-uploads) | File validation, malware scanning, signed-URL serving |
 | [`artisanpack-ui/security-analytics`](https://github.com/ArtisanPack-UI/security-analytics) | Event logging, anomaly detection, SIEM, dashboards |
+| [`artisanpack-ui/compliance`](https://github.com/ArtisanPack-UI/compliance) | GDPR / CCPA / LGPD consent, data subject rights, DPIA, retention, monitoring |
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Role-based access control for Laravel — roles with hierarchy, permissions, Blade directives, middleware, and Gate integration.",
   "type": "library",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "keywords": [
     "laravel",
     "security",

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,17 @@
   "name": "artisanpack-ui/rbac",
   "description": "Role-based access control for Laravel — roles with hierarchy, permissions, Blade directives, middleware, and Gate integration.",
   "type": "library",
-  "license": "GPL-3.0-or-later",
+  "license": "MIT",
   "version": "0.1.0",
+  "keywords": [
+    "laravel",
+    "security",
+    "rbac",
+    "roles",
+    "permissions",
+    "authorization",
+    "access-control"
+  ],
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\Rbac\\": "src/"
@@ -20,7 +29,7 @@
   "authors": [
     {
       "name": "Jacob Martella",
-      "email": "me@jacobmartella.com"
+      "email": "support@artisanpackui.dev"
     }
   ],
   "require": {

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,13 @@
+---
+title: Advanced
+---
+
+# Advanced
+
+Topics beyond the day-to-day usage path.
+
+## Topics
+
+- [Extending the base models](advanced/extending-models.md) — substitute your own `Role` / `Permission` subclasses without forking the package
+- [Events](advanced/events.md) — observer + pivot events you can subscribe to
+- [Caching](advanced/caching.md) — how the two caches work, TTLs, invalidation rules, tuning

--- a/docs/advanced/caching.md
+++ b/docs/advanced/caching.md
@@ -69,9 +69,20 @@ The defaults work well for most apps. Tune up or down based on your traffic and 
 When you bypass Eloquent, call invalidation yourself:
 
 ```php
-Cache::tags(config('artisanpack.rbac.cache.tag'))->flush();
+use Illuminate\Cache\TaggableStore;
+use Illuminate\Support\Facades\Cache;
+
+if ( Cache::getStore() instanceof TaggableStore ) {
+    Cache::tags( config( 'artisanpack.rbac.cache.tag' ) )->flush();
+} else {
+    // Non-taggable store (file, database, array) — flush the known key directly.
+    Cache::forget( 'rbac_permission_names' );
+}
+
 $user->flushPermissionCache();
 ```
+
+`Cache::tags(...)->flush()` throws `BadMethodCallException` on non-taggable drivers (`file`, `database`, `array`). The capability check above lets the same code path work everywhere.
 
 ## Disabling the cache
 

--- a/docs/advanced/caching.md
+++ b/docs/advanced/caching.md
@@ -1,0 +1,83 @@
+---
+title: Caching
+---
+
+# Caching
+
+The package maintains two caches to keep authorization checks fast under load. Both use the application's default cache store and are tag-scoped when the store supports tags (`redis`, `memcached`).
+
+## The two caches
+
+### 1. Permission names cache
+
+| Property | Value |
+|---|---|
+| Purpose | Fast-path the `Gate::before` hook so it only delegates to `hasPermissionTo()` for abilities that actually match a registered permission |
+| Cache key | `rbac_permission_names` |
+| Content | Array of all `Permission` `name` and `slug` values |
+| TTL | `artisanpack.rbac.cache.permission_names_ttl` (default 3600 seconds) |
+| Built by | `RbacServiceProvider::getCachedPermissionNames()` |
+| Invalidated by | `PermissionObserver` on `created`, `updated`, `deleted` |
+
+Without this cache, every `$user->can(...)` call would hit the database to check if the ability is an RBAC permission. With the cache, the check is an `in_array()` lookup against a preloaded array.
+
+### 2. User permissions cache
+
+| Property | Value |
+|---|---|
+| Purpose | Avoid repeating the recursive role-hierarchy walk on every authorization check for the same user |
+| Cache key | per-user, internal to `HasPermissions` |
+| Content | The user's resolved permission collection (union of direct + inherited via parent roles) |
+| TTL | `artisanpack.rbac.cache.user_permissions_ttl` (default 60 seconds) |
+| Built by | `HasPermissions::hasPermissionTo()` on first call |
+| Invalidated by | Observer events on role / permission CRUD; manually via `$user->flushPermissionCache()` |
+
+A short TTL (60s default) keeps the cache fresh without sacrificing the speedup for back-to-back checks within a single request.
+
+## Tag scoping
+
+When the cache store implements `Illuminate\Cache\TaggableStore` (i.e. `redis` or `memcached`), both caches are tagged with `artisanpack.rbac.cache.tag` (default `'rbac'`). This lets the package flush only its own entries:
+
+```php
+Cache::tags('rbac')->forget('rbac_permission_names');
+Cache::tags('rbac')->flush();   // nuke every RBAC cache entry
+```
+
+For non-tagged stores (`file`, `database`, `array`), the package falls back to plain `Cache::remember()` / `Cache::forget()` calls. Functionality is identical; you just can't bulk-flush only the RBAC entries — you'd have to wait for TTL or call `Cache::flush()` (which clears everything).
+
+## Tuning the TTLs
+
+The defaults work well for most apps. Tune up or down based on your traffic and update frequency:
+
+| Scenario | Suggested adjustment |
+|---|---|
+| Low-traffic admin app, permissions change daily | Increase both TTLs (e.g. `user_permissions_ttl` → 600, `permission_names_ttl` → 86400) |
+| High-traffic public app, permissions rarely change | Keep defaults — the auto-invalidation handles freshness; the cache absorbs the hot path |
+| Permissions change via direct DB mutation (no Eloquent) | Drop both TTLs to ~10 seconds so stale data clears quickly, since observers don't fire |
+
+## Invalidation matrix
+
+| Mutation path | Permission-names cache | User-permissions cache |
+|---|---|---|
+| `Permission::create / update / delete` | flushed (via observer) | flushed (via observer) |
+| `Role::create / update / delete` | not flushed | flushed (via observer) |
+| `$role->permissions()->attach / detach / sync` | not flushed | not flushed automatically |
+| `$user->roles()->attach / detach` (raw pivot) | not flushed | not flushed |
+| `$user->assignRole / removeRole` | not flushed | flushed |
+| Raw `DB::table('permissions')->insert(...)` | not flushed | not flushed |
+
+When you bypass Eloquent, call invalidation yourself:
+
+```php
+Cache::tags(config('artisanpack.rbac.cache.tag'))->flush();
+$user->flushPermissionCache();
+```
+
+## Disabling the cache
+
+There's no first-class disable flag. The simplest options:
+
+- Set TTLs to `0` — every check effectively bypasses the cache.
+- Use the `array` cache driver in CI / testing — the cache lives only for the request.
+
+In production, leave the cache on. The `Gate::before` hook is on every authorization check; a cache miss there is expensive enough that disabling the cache hurts more than it helps.

--- a/docs/advanced/events.md
+++ b/docs/advanced/events.md
@@ -1,0 +1,74 @@
+---
+title: Events
+---
+
+# Events
+
+The package emits two families of events: Eloquent observer events on the models, and pivot events on `HasRoles` assignment / removal.
+
+All event names use the `rbac.` prefix and Laravel's string-event syntax — listen for them via `Event::listen('rbac.role.created', $listener)` or in `EventServiceProvider::$listen`.
+
+## Observer events
+
+Dispatched by `RoleObserver` and `PermissionObserver` (attached to the configured model classes in the service provider).
+
+| Event | Payload | Source |
+|---|---|---|
+| `rbac.role.created` | `Role $role` | `RoleObserver::created` |
+| `rbac.role.updated` | `Role $role` | `RoleObserver::updated` |
+| `rbac.role.deleted` | `Role $role` | `RoleObserver::deleted` |
+| `rbac.permission.created` | `Permission $permission` | `PermissionObserver::created` |
+| `rbac.permission.updated` | `Permission $permission` | `PermissionObserver::updated` |
+| `rbac.permission.deleted` | `Permission $permission` | `PermissionObserver::deleted` |
+
+## Pivot events
+
+Laravel does not fire Eloquent events on pivot operations, so these are dispatched directly from the `HasRoles` trait.
+
+| Event | Payload | Source |
+|---|---|---|
+| `rbac.user.role_assigned` | `Authenticatable $user`, `Role $role` | `HasRoles::assignRole` |
+| `rbac.user.role_removed` | `Authenticatable $user`, `Role $role` | `HasRoles::removeRole` |
+
+These fire only when the assignment / removal actually changes state (the trait is idempotent — assigning a role a user already holds is a no-op and does not fire the event).
+
+## Listening
+
+```php
+use Illuminate\Support\Facades\Event;
+
+Event::listen('rbac.user.role_assigned', function ($user, $role) {
+    logger()->info("User {$user->id} assigned role {$role->slug}");
+});
+
+Event::listen('rbac.role.deleted', function ($role) {
+    logger()->warning("Role {$role->slug} was deleted");
+});
+```
+
+Or in `EventServiceProvider`:
+
+```php
+protected $listen = [
+    'rbac.user.role_assigned' => [
+        LogRoleAssignment::class,
+    ],
+    'rbac.role.deleted' => [
+        AlertOnRoleDeletion::class,
+    ],
+];
+```
+
+## Use cases
+
+**Audit logging** — `artisanpack-ui/security-analytics` subscribes to all six observer events and both pivot events to maintain an audit trail of authorization changes.
+
+**Cache invalidation in downstream packages** — if you cache derived data based on roles or permissions (e.g. a precomputed permission list per organisation), subscribe to the observer events and flush your cache there.
+
+**Notifications** — listen for `rbac.user.role_assigned` to notify the user they've been granted a new role.
+
+**Sync to external systems** — sync role assignments to an external SSO or IdP by listening for the pivot events.
+
+## Direct pivot mutations
+
+If you mutate the `role_user` pivot directly (e.g. `$user->roles()->attach($id)` instead of `$user->assignRole(...)`), the pivot events do **not** fire. Always prefer `assignRole()` / `removeRole()` unless you have a specific reason to bypass them. When you do bypass them, call `$user->flushPermissionCache()` afterwards so the permission cache stays consistent.

--- a/docs/advanced/extending-models.md
+++ b/docs/advanced/extending-models.md
@@ -1,0 +1,65 @@
+---
+title: Extending the Base Models
+---
+
+# Extending the Base Models
+
+The `Role` and `Permission` model classes are bound via config, so you can substitute your own subclasses without forking the package. Useful when a downstream package or application needs to add relationships, scopes, or behaviour to the base models.
+
+The `cms-framework` package uses this pattern for its Users module — its `Role` subclass adds a `policies()` relationship without forking RBAC.
+
+## 1. Subclass the base model
+
+```php
+namespace App\Models;
+
+use ArtisanPackUI\Rbac\Models\Role as BaseRole;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Role extends BaseRole
+{
+    protected $table = 'roles';
+
+    public function policies(): HasMany
+    {
+        return $this->hasMany(Policy::class);
+    }
+}
+```
+
+Critical: **extend the base model**. Don't reimplement it. The traits, observers, migrations, and Artisan commands all rely on the base methods + casts.
+
+## 2. Register your subclass
+
+```php
+// config/artisanpack/rbac.php
+return [
+    'models' => [
+        'role'       => App\Models\Role::class,
+        'permission' => ArtisanPackUI\Rbac\Models\Permission::class,
+    ],
+
+    // ... rest of config
+];
+```
+
+## 3. That's it
+
+Everything that touches the model — Artisan commands, observers, `HasRoles::roles()`, the Gate integration, the Blade directives — reads from the config and uses your subclass. You can keep adding methods, scopes, and relationships on `App\Models\Role` indefinitely.
+
+## What you can't change this way
+
+The base columns (`name`, `slug`, `description`, `parent_id` for `Role`) are baked into the shipped migration. If you need different columns, ship your own migration that alters the tables after the package's migration runs.
+
+The pivot tables (`role_user`, `permission_role`) are configurable by name (see [`tables`](../installation/configuration.md#tables)) but their column shape isn't. If you need additional pivot columns, override `getPivotColumns()` on your subclass and ship a migration that adds them.
+
+## Subclassing both Role and Permission
+
+```php
+'models' => [
+    'role'       => App\Models\Role::class,
+    'permission' => App\Models\Permission::class,
+],
+```
+
+Same pattern. The base classes are independent — subclassing one doesn't require subclassing the other.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -62,7 +62,7 @@ Or sync to set the exact list:
 $permission->roles()->sync($roleIds);
 ```
 
-Both go through standard Eloquent. The permission's update event fires once, triggering cache invalidation for the user-permissions cache.
+Both go through standard Eloquent's `BelongsToMany`. Pivot `attach()` / `detach()` / `sync()` operations do **not** fire model events on the `Permission` or `Role`, so the permission-names cache and user-permissions cache are not invalidated automatically. If you mutate role-permission relationships directly via the pivot, call `$user->flushPermissionCache()` for each affected user (or rely on the per-request cache miss to pick up the new state).
 
 ## Where do the `rbac.*` events come from?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,69 @@
+---
+title: FAQ
+---
+
+# FAQ
+
+## Does this package depend on `artisanpack-ui/security`?
+
+No. `rbac` is standalone — it pulls in only `artisanpack-ui/core` and standard Laravel packages. It's safe to install in any Laravel app or package, including ones that don't use the rest of the ArtisanPack UI security ecosystem.
+
+## Can a user have more than one role?
+
+Yes. `HasRoles::assignRole()` doesn't restrict the count — you can stack as many roles as you want on a user. Permissions resolve as the union across all of the user's roles (and their ancestors).
+
+## Can a role inherit from more than one parent?
+
+No. The `parent_id` column is a single foreign key — each role has at most one parent. If you need multiple inheritance, you'll need to give the user multiple direct roles instead.
+
+## How deep can the role hierarchy go?
+
+There's no hard limit, but every level adds one more database query when resolving permissions (unless the user-permissions cache is warm). For most apps, 3–4 levels is plenty; if you find yourself going deeper, consider whether some of those levels could be replaced with multiple direct role assignments.
+
+## How is this different from `spatie/laravel-permission`?
+
+- This package supports role hierarchy (`parent_id`); Spatie's doesn't.
+- This package is intentionally smaller — no team / guard scoping, no JSON column for permissions, no Bouncer-style abilities.
+- This package's models are subclassable via config without a `morphMap`-style indirection.
+- This package emits dedicated `rbac.*` events that downstream packages (notably `artisanpack-ui/security-analytics`) subscribe to for auditing.
+
+If you need teams or guards, Spatie's is the better fit. If you need role hierarchy or you're already in the ArtisanPack UI ecosystem, use this one.
+
+## Can I use this with multi-tenancy?
+
+Yes, but the package doesn't ship a tenant-aware scope. The simplest pattern: subclass `Role` and `Permission`, add a `tenant_id` column via your own migration, and override the `roles()` and `permissions()` relationships to apply the tenant scope. Bind your subclasses via config.
+
+## Does `assignRole()` work transactionally?
+
+It uses Eloquent's `BelongsToMany::attach()` under the hood, which performs a single insert. If you wrap a batch of role assignments in `DB::transaction()`, the whole batch is atomic.
+
+## Why does `findBySlug` exist when I have `whereSlug`?
+
+`findBySlug('editor')` is shorthand for `Role::whereSlug('editor')->first()`. Same result, less code at the call site. Pick whichever reads better for the context.
+
+## What happens if I delete a user with assigned roles?
+
+Standard Eloquent behaviour applies — the `role_user` pivot rows orphan unless you've set up the foreign key with `onDelete('cascade')`. The package's migrations don't cascade on the user side because the package can't assume control of the users table; add cascading yourself if you want it.
+
+## Can two roles have the same name?
+
+No. `name` is unique on the `roles` table, and `Role::save()` actively checks for collision with existing `slug` values too (and vice versa). This prevents lookup ambiguity for the slug-based helpers.
+
+## How do I bulk-assign a permission to many roles?
+
+```php
+$roleIds = Role::whereIn('slug', ['editor', 'admin', 'publisher'])->pluck('id');
+$permission->roles()->attach($roleIds);
+```
+
+Or sync to set the exact list:
+
+```php
+$permission->roles()->sync($roleIds);
+```
+
+Both go through standard Eloquent. The permission's update event fires once, triggering cache invalidation for the user-permissions cache.
+
+## Where do the `rbac.*` events come from?
+
+See [Events](advanced/events.md). They're standard Laravel string events dispatched from `RoleObserver`, `PermissionObserver`, and the `HasRoles` trait. Listen for them via `Event::listen()` or `EventServiceProvider::$listen`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,92 @@
+---
+title: Getting Started
+---
+
+# Getting Started
+
+A five-minute path from install to a working role / permission check.
+
+## 1. Install
+
+```bash
+composer require artisanpack-ui/rbac
+php artisan migrate
+```
+
+## 2. Add the traits to your User model
+
+```php
+use ArtisanPackUI\Rbac\Concerns\HasPermissions;
+use ArtisanPackUI\Rbac\Concerns\HasRoles;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    use HasPermissions;
+    use HasRoles;
+}
+```
+
+## 3. Create a role and a permission
+
+```php
+use ArtisanPackUI\Rbac\Models\Permission;
+use ArtisanPackUI\Rbac\Models\Role;
+
+$editor = Role::create(['name' => 'editor']);
+$publish = Permission::create(['name' => 'posts.publish']);
+
+$editor->permissions()->attach($publish);
+```
+
+Or use Artisan:
+
+```bash
+php artisan role:create editor
+php artisan permission:create posts.publish
+```
+
+## 4. Assign the role to a user
+
+```php
+$user->assignRole('editor');
+```
+
+Or:
+
+```bash
+php artisan user:assign-role user@example.com editor
+```
+
+## 5. Check authorization
+
+```php
+$user->hasRole('editor');                // true
+$user->hasPermissionTo('posts.publish'); // true
+$user->can('posts.publish');             // true — via Gate integration
+```
+
+In a route:
+
+```php
+Route::get('/posts/{post}/publish', PublishController::class)
+    ->middleware('permission:posts.publish');
+```
+
+In a Blade view:
+
+```blade
+@permission('posts.publish')
+    <button>Publish</button>
+@endpermission
+
+@role('editor')
+    <a href="/editor">Editor dashboard</a>
+@endrole
+```
+
+## Next steps
+
+- [Usage](usage.md) — full reference for the traits, middleware, directives, and Gate integration.
+- [Advanced](advanced.md) — extending the base models, listening for events, tuning the cache.
+- [Installation](installation.md) — requirements, configuration, and integration with existing schemas.

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,0 +1,40 @@
+---
+title: ArtisanPack UI RBAC Documentation
+---
+
+# ArtisanPack UI RBAC
+
+Role-based access control for Laravel: roles with hierarchy, permissions, Blade directives, middleware, and Gate integration.
+
+This package is **standalone** — it does not depend on `artisanpack-ui/security` and can be used by any Laravel application or package (e.g. `cms-framework`) that needs roles and permissions without pulling in the full security suite.
+
+## What's in this package
+
+- Eloquent `Role` and `Permission` models with parent / child role hierarchy
+- `HasRoles` and `HasPermissions` traits for the User model
+- Recursive permission resolution through the role hierarchy, with per-user caching
+- Route middleware (`permission:slug,slug`) for permission-gated routes
+- `@role` and `@permission` Blade directives
+- Gate integration (`$user->can('slug')`, `Gate::allows('slug')`, `@can('slug')`) backed by RBAC permissions
+- Artisan commands for CRUD over roles and role assignments
+- Configurable model bindings so consumers can extend `Role` / `Permission` with their own subclasses
+- Eloquent observer events on the `rbac.*` channel for downstream auditing
+
+## Documentation map
+
+- [Getting Started](getting-started.md) — 5-minute install + first role / permission
+- [Installation](installation.md) — install, requirements, configuration
+- [Usage](usage.md) — roles, permissions, middleware, Blade directives, Gate integration, Artisan commands
+- [Advanced](advanced.md) — extending the base models, events, caching
+- [FAQ](faq.md)
+- [Troubleshooting](troubleshooting.md)
+
+## Related packages
+
+| Package | Scope |
+|---|---|
+| [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: input sanitization, output escaping, KSES, CSP, security headers |
+| [`artisanpack-ui/security-auth`](https://github.com/ArtisanPack-UI/security-auth) | 2FA, password complexity, account lockout, sessions |
+| [`artisanpack-ui/security-advanced-auth`](https://github.com/ArtisanPack-UI/security-advanced-auth) | WebAuthn, SSO, social login |
+| [`artisanpack-ui/secure-uploads`](https://github.com/ArtisanPack-UI/secure-uploads) | File validation, malware scanning, secure storage |
+| [`artisanpack-ui/security-analytics`](https://github.com/ArtisanPack-UI/security-analytics) | Event logging, anomaly detection, SIEM, dashboards (subscribes to `rbac.*` events) |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,50 @@
+---
+title: Installation
+---
+
+# Installation
+
+## Install via Composer
+
+```bash
+composer require artisanpack-ui/rbac
+```
+
+The package auto-registers via Laravel's package discovery — no manual service provider entry is required.
+
+## Run migrations
+
+```bash
+php artisan migrate
+```
+
+Four tables are created: `roles`, `permissions`, `role_user`, and `permission_role`.
+
+## (Optional) Publish the config
+
+```bash
+php artisan vendor:publish --tag=rbac-config
+```
+
+Publishes `config/artisanpack/rbac.php`. Override model bindings, table names, foreign keys, user lookup fields, or cache settings here.
+
+## Add the traits to your User model
+
+```php
+use ArtisanPackUI\Rbac\Concerns\HasPermissions;
+use ArtisanPackUI\Rbac\Concerns\HasRoles;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    use HasPermissions;
+    use HasRoles;
+}
+```
+
+Both traits are independent — you can use just `HasRoles` if you only need role assignment, but `HasPermissions` requires `HasRoles` to resolve permissions through the role hierarchy.
+
+## Deeper topics
+
+- [Requirements](installation/requirements.md) — PHP / Laravel versions, cache driver notes
+- [Configuration](installation/configuration.md) — full config reference

--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -1,0 +1,74 @@
+---
+title: Configuration
+---
+
+# Configuration
+
+Publish the config file to override any of the defaults:
+
+```bash
+php artisan vendor:publish --tag=rbac-config
+```
+
+The full config (`config/artisanpack/rbac.php`):
+
+```php
+<?php
+
+return [
+    'models' => [
+        'role'       => ArtisanPackUI\Rbac\Models\Role::class,
+        'permission' => ArtisanPackUI\Rbac\Models\Permission::class,
+    ],
+
+    'tables' => [
+        'role_user'       => 'role_user',
+        'permission_role' => 'permission_role',
+        'users'           => 'users',
+    ],
+
+    'foreign_keys' => [
+        'user' => 'user_id',
+    ],
+
+    'user_lookup_fields' => ['email'],
+
+    'cache' => [
+        'user_permissions_ttl' => 60,
+        'permission_names_ttl' => 3600,
+        'tag'                  => 'rbac',
+    ],
+];
+```
+
+## `models`
+
+Concrete classes used for the Role and Permission models. Override these when extending the base models — see [Extending the base models](../advanced/extending-models.md). Any class declared here must extend the corresponding base model so the observers, traits, and migrations continue to work.
+
+## `tables`
+
+Names of the pivot tables backing the role-permission and role-user relationships, plus the `users` table name. Override these only when integrating with a legacy schema; the defaults match the migrations shipped in this package.
+
+## `foreign_keys`
+
+Column name for the user side of the `role_user` pivot. Defaults to `user_id`.
+
+## `user_lookup_fields`
+
+Columns the `user:assign-role` and `user:revoke-role` Artisan commands query when the supplied identifier isn't numeric. Defaults to `['email']` so the package works on any standard Laravel users table; apps with a `username` column (or other unique handles) should append them:
+
+```php
+'user_lookup_fields' => ['email', 'username'],
+```
+
+## `cache`
+
+Tunes the two caches the package maintains:
+
+| Key | Default | What it caches |
+|---|---|---|
+| `user_permissions_ttl` | `60` (seconds) | A user's resolved permission collection (per user) |
+| `permission_names_ttl` | `3600` (seconds) | The list of all known permission names / slugs for the `Gate::before` fast-path |
+| `tag` | `'rbac'` | Cache tag used when a tagged cache store is available |
+
+See [Caching](../advanced/caching.md) for invalidation rules and tuning advice.

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -1,0 +1,38 @@
+---
+title: Requirements
+---
+
+# Requirements
+
+## PHP
+
+- PHP 8.2 or higher
+
+## Laravel
+
+- Laravel 10 / 11 / 12
+
+The package targets `illuminate/support: ^10.0|^11.0|^12.0`. No compatibility shims — if you're on Laravel 9 or below, stay on `artisanpack-ui/security` 1.x.
+
+## Dependencies
+
+The only runtime dependency outside Laravel is `artisanpack-ui/core` (^1.0), pulled in automatically by Composer.
+
+## Cache driver
+
+The package caches resolved permission names and per-user permission collections. Any Laravel cache driver works, but **tagged caches** (`redis`, `memcached`) give the most precise invalidation:
+
+| Driver | Cache invalidation strategy |
+|---|---|
+| `redis` / `memcached` | Tag-scoped — only RBAC entries are flushed when permissions change |
+| `file` / `database` / `array` | Key-based — the package falls back to individual `forget()` calls |
+
+If you're using `file` or `database` cache, the package still works correctly; you just lose the per-tag granularity. See [Caching](../advanced/caching.md) for tuning.
+
+## Database
+
+Any Eloquent-supported driver (MySQL, PostgreSQL, SQLite, SQL Server). The migrations use standard column types — no driver-specific syntax.
+
+## Auth provider
+
+The package reads `config('auth.providers.users.model')` to identify the User model for the `role_user` pivot. The standard Laravel auth setup is sufficient; custom guards work as long as the underlying provider exposes a user model.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,98 @@
+---
+title: Troubleshooting
+---
+
+# Troubleshooting
+
+## `Call to undefined method App\Models\User::hasRole()`
+
+The `HasRoles` trait isn't applied. Add it to your User model:
+
+```php
+use ArtisanPackUI\Rbac\Concerns\HasPermissions;
+use ArtisanPackUI\Rbac\Concerns\HasRoles;
+
+class User extends Authenticatable
+{
+    use HasPermissions;
+    use HasRoles;
+}
+```
+
+## `hasPermissionTo()` returns false even though the user has the role
+
+Three common causes:
+
+1. **The permission isn't attached to the role.** Check via `$role->permissions` or in the database.
+2. **The user-permissions cache is stale.** This can happen if you mutated pivot tables directly (e.g. `$user->roles()->attach($id)`) without calling `assignRole()`. Run `$user->flushPermissionCache()` and try again.
+3. **You're checking with the slug but stored the name (or vice versa).** Both the trait and the Gate integration check `name` AND `slug`. Verify the permission's `name` and `slug` columns in the database match what you're passing in.
+
+## `$user->can('my.permission')` returns false but `$user->hasPermissionTo('my.permission')` returns true
+
+The Gate `before` hook is cached. If you recently created `my.permission` and the permission-names cache hasn't picked it up yet, `Gate::before` won't recognize the ability and will fall through to standard authorization, which returns false (no policy defined).
+
+Flush the cache manually:
+
+```php
+Cache::tags(config('artisanpack.rbac.cache.tag'))->flush();
+```
+
+Or restart your queue worker / php-fpm pool if the cache lives in-process.
+
+The `PermissionObserver` invalidates this cache automatically on `created` / `updated` / `deleted`, so this only happens when you create permissions outside of Eloquent (e.g. raw SQL, seeders that bypass observers).
+
+## `Class 'ArtisanPackUI\Rbac\Models\Role' not found` after publishing config
+
+You probably published the config and then edited a `'role'` model class to a class that doesn't exist. Open `config/artisanpack/rbac.php` and verify the FQCN is correct and autoloadable. The package's defaults are:
+
+```php
+'models' => [
+    'role'       => ArtisanPackUI\Rbac\Models\Role::class,
+    'permission' => ArtisanPackUI\Rbac\Models\Permission::class,
+],
+```
+
+## Migrations fail with "table already exists"
+
+The migrations don't have `Schema::hasTable()` guards. If you're integrating into an app that already has `roles` or `permissions` tables (e.g. from a previous package), you'll need to either:
+
+- Drop the existing tables before running the migration, or
+- Skip the package's migrations and manage the schema yourself
+
+## `Role name/slug collision` exception on save
+
+The `save()` method on `Role` and `Permission` checks for name / slug collisions across columns. The exception means a row already exists where the `name` you're saving matches another row's `slug`, or vice versa. Pick distinct values.
+
+## `permission` middleware always returns 401 even for logged-in users
+
+The middleware uses `Auth::guest()` and `Auth::user()` — make sure the request is actually going through Laravel's auth middleware first. Apply middleware in the right order:
+
+```php
+Route::middleware(['auth', 'permission:posts.publish'])->group(function () {
+    // ...
+});
+```
+
+If you're using a non-default guard, set it via `Auth::shouldUse('api')` or in your route group's `auth:api` middleware before the `permission` check.
+
+## Tests pass locally but fail in CI
+
+Most common: the CI environment has a different cache driver. The package's behaviour is the same across drivers, but if your tests assert against specific cache keys, the tag-vs-non-tag fallback paths produce slightly different keys. Use `array` cache in tests for predictability:
+
+```php
+// phpunit.xml
+<env name="CACHE_DRIVER" value="array"/>
+```
+
+## `@permission` and `@role` directives render nothing for authenticated users
+
+Either the user doesn't actually hold the role / permission, or the User model doesn't use the `HasRoles` trait. The `@role` directive specifically guards on `method_exists($user, 'hasRole')` and silently renders nothing if the method is missing.
+
+## Still stuck?
+
+Open an issue at https://github.com/ArtisanPack-UI/rbac/issues with:
+
+- Your PHP and Laravel versions
+- The relevant code (User model, route definition, Blade snippet, etc.)
+- The exact behaviour you're seeing vs what you expected
+- The cache driver you're using

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,46 @@
+---
+title: Usage
+---
+
+# Usage
+
+The package exposes its functionality through five layers — models, traits, middleware, Blade directives, and Gate integration — plus a set of Artisan commands for CRUD. Each has its own page below.
+
+## Topics
+
+- [Roles](usage/roles.md) — the `Role` model, hierarchy, slug helpers
+- [Permissions](usage/permissions.md) — the `Permission` model, slug helpers
+- [User traits (`HasRoles`, `HasPermissions`)](usage/user-traits.md)
+- [Middleware (`permission:slug,slug`)](usage/middleware.md)
+- [Blade directives (`@role`, `@permission`)](usage/blade-directives.md)
+- [Gate integration](usage/gate-integration.md)
+- [Artisan commands](usage/artisan-commands.md)
+
+## Quick reference
+
+```php
+// Models
+$editor   = Role::create(['name' => 'editor']);
+$publish  = Permission::create(['name' => 'posts.publish']);
+$editor->permissions()->attach($publish);
+
+// Traits (on User)
+$user->assignRole('editor');
+$user->hasRole('editor');
+$user->hasPermissionTo('posts.publish');
+
+// Gate
+$user->can('posts.publish');
+Gate::allows('posts.publish');
+
+// Middleware
+Route::middleware('permission:posts.publish');
+
+// Blade
+@role('editor') ... @endrole
+@permission('posts.publish') ... @endpermission
+
+// Artisan
+php artisan role:create editor
+php artisan user:assign-role user@example.com editor
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,8 +39,10 @@ Route::middleware('permission:posts.publish');
 // Blade
 @role('editor') ... @endrole
 @permission('posts.publish') ... @endpermission
+```
 
-// Artisan
+```bash
+# Artisan
 php artisan role:create editor
 php artisan user:assign-role user@example.com editor
 ```

--- a/docs/usage/artisan-commands.md
+++ b/docs/usage/artisan-commands.md
@@ -1,0 +1,93 @@
+---
+title: Artisan Commands
+---
+
+# Artisan Commands
+
+Four commands for CRUD on roles and role assignments.
+
+## `role:create`
+
+```bash
+php artisan role:create {name} [--slug=...] [--description=...]
+```
+
+Creates a new role.
+
+| Argument / option | Required | Description |
+|---|---|---|
+| `name` | yes | Role name (also used to derive the slug if `--slug` is omitted) |
+| `--slug` | no | Override the auto-derived slug |
+| `--description` | no | Human-readable description |
+
+Examples:
+
+```bash
+php artisan role:create Editor
+php artisan role:create "Content Editor" --slug=editor
+php artisan role:create Admin --description="Full administrative access"
+```
+
+## `permission:create`
+
+```bash
+php artisan permission:create {name} [--slug=...] [--description=...]
+```
+
+Creates a new permission. Same shape as `role:create`.
+
+```bash
+php artisan permission:create posts.publish
+php artisan permission:create "Publish Posts" --slug=posts.publish
+```
+
+Creating a permission flushes the Gate `before` cache automatically, so the new permission is immediately usable in `$user->can(...)` checks on the next request.
+
+## `user:assign-role`
+
+```bash
+php artisan user:assign-role {user} {role}
+```
+
+Idempotent — assigning a role to a user who already holds it is a no-op.
+
+| Argument | Notes |
+|---|---|
+| `user` | User ID (numeric) **or** any value matching one of `artisanpack.rbac.config.user_lookup_fields` (default `email`) |
+| `role` | Role name or slug |
+
+Examples:
+
+```bash
+php artisan user:assign-role 42 admin
+php artisan user:assign-role user@example.com editor
+```
+
+If you've added `username` to `user_lookup_fields`, you can also use:
+
+```bash
+php artisan user:assign-role jdoe editor
+```
+
+Dispatches the `rbac.user.role_assigned` event on success.
+
+## `user:revoke-role`
+
+```bash
+php artisan user:revoke-role {user} {role}
+```
+
+Same argument shape as `user:assign-role`. Idempotent — revoking a role a user doesn't hold is a no-op. Dispatches the `rbac.user.role_removed` event on success.
+
+```bash
+php artisan user:revoke-role user@example.com editor
+```
+
+## Exit codes
+
+All four commands return:
+
+- `0` on success
+- `1` on lookup failure (user or role not found)
+
+The commands print human-readable messages either way.

--- a/docs/usage/blade-directives.md
+++ b/docs/usage/blade-directives.md
@@ -1,0 +1,73 @@
+---
+title: Blade Directives
+---
+
+# Blade Directives
+
+The service provider registers two pairs of directives for view-layer authorization.
+
+## `@role`
+
+Renders the inner block only if the authenticated user holds the named role.
+
+```blade
+@role('admin')
+    <a href="/admin">Admin dashboard</a>
+@endrole
+```
+
+- Argument: role name **or** slug (matched against both).
+- Unauthenticated users: directive renders nothing.
+- Matching: checks `auth()->user()->hasRole(...)` if the user has the `HasRoles` trait; safely renders nothing if the User model doesn't implement `hasRole()`.
+
+## `@permission`
+
+Renders the inner block only if the authenticated user holds the named permission, including permissions inherited through the role hierarchy.
+
+```blade
+@permission('posts.publish')
+    <button>Publish</button>
+@endpermission
+```
+
+- Argument: permission name **or** slug.
+- Unauthenticated users: directive renders nothing.
+- Resolution: routes through `$user->can(...)`, which dispatches to the Gate integration and ultimately `HasPermissions::hasPermissionTo()`.
+
+## `@permission` vs `@can`
+
+`@can` is Laravel's built-in directive. Because the package wires permissions through `Gate::before`, `@can('posts.publish')` and `@permission('posts.publish')` resolve to the same result.
+
+```blade
+@can('posts.publish')
+    <button>Publish</button>
+@endcan
+```
+
+Use whichever reads better in context. `@permission` makes the intent ("this is an RBAC permission") explicit; `@can` is consistent with the rest of your Laravel codebase. Both are fine.
+
+## Combining with policies
+
+`@can` (and the underlying `Gate::allows`) checks the RBAC permission first via `Gate::before`. If the ability doesn't match a known permission slug, control falls through to your defined policies. This means:
+
+```blade
+@can('update', $post)
+    <button>Edit</button>
+@endcan
+```
+
+…runs your `PostPolicy::update($user, $post)` even when the RBAC package is installed, because `update` isn't a registered permission slug. RBAC permissions and per-resource policies coexist cleanly.
+
+## Reference: directive expansions
+
+The directives expand to inline PHP guards:
+
+```php
+// @role('admin')
+<?php if(auth()->check() && method_exists(auth()->user(), 'hasRole') && auth()->user()->hasRole('admin')): ?>
+
+// @permission('posts.publish')
+<?php if(auth()->check() && auth()->user()->can('posts.publish')): ?>
+```
+
+…and the closers expand to `<?php endif; ?>`.

--- a/docs/usage/gate-integration.md
+++ b/docs/usage/gate-integration.md
@@ -1,0 +1,89 @@
+---
+title: Gate Integration
+---
+
+# Gate Integration
+
+The service provider registers a `Gate::before` hook so any ability matching a known permission slug resolves through `HasPermissions::hasPermissionTo()`. Standard Laravel authorization patterns work out of the box.
+
+## What this gives you
+
+```php
+$user->can('posts.publish');           // true | false
+$user->cannot('posts.publish');        // true | false
+Gate::allows('posts.publish');         // true | false
+Gate::denies('posts.publish');         // true | false
+```
+
+```blade
+@can('posts.publish')
+    <button>Publish</button>
+@endcan
+```
+
+```php
+// In a controller, request, or policy
+$this->authorize('posts.publish');     // throws AuthorizationException if denied
+```
+
+All of these route through the same `Gate::before` hook and ultimately call `HasPermissions::hasPermissionTo()`.
+
+## How the hook works
+
+```php
+Gate::before(function ($user, $ability) {
+    if (! method_exists($user, 'hasPermissionTo')) {
+        return null;
+    }
+
+    $permissionNames = $this->getCachedPermissionNames();
+
+    if (in_array($ability, $permissionNames, true)) {
+        return $user->hasPermissionTo($ability);
+    }
+
+    return null;
+});
+```
+
+- Returning `true` or `false` from a `Gate::before` callback short-circuits the entire authorization check.
+- Returning `null` defers to subsequent `Gate::before` callbacks and then to policies.
+- The hook only short-circuits when the ability matches a known permission slug. Abilities like `update` or `delete-post` that don't correspond to RBAC permissions fall through to your policies untouched.
+
+## Coexistence with policies
+
+This is the most important property of the integration. RBAC permissions and Laravel policies do not compete — they compose.
+
+```php
+// PostPolicy
+public function update(User $user, Post $post): bool
+{
+    return $user->id === $post->author_id;
+}
+```
+
+```php
+$user->can('posts.publish');       // resolves through RBAC (matches a permission slug)
+$user->can('update', $post);       // resolves through PostPolicy (no matching slug)
+```
+
+You can use RBAC for the "broad capability" question ("can this user publish posts at all?") and policies for the "specific instance" question ("can this user edit *this* post?").
+
+## Performance: the permission-names cache
+
+`Gate::before` runs on every authorization check. Looking up every ability against the database would be expensive, so the hook keeps a cache of all known permission names + slugs and only delegates to `hasPermissionTo()` when there's a match.
+
+The cache:
+
+- Key: `rbac_permission_names`
+- TTL: `artisanpack.rbac.cache.permission_names_ttl` (default 3600 seconds)
+- Storage: tagged cache when available (`redis` / `memcached`), plain cache otherwise
+- Invalidation: automatic on `Permission::created`, `Permission::updated`, `Permission::deleted` via `PermissionObserver`
+
+See [Caching](../advanced/caching.md) for tuning.
+
+## Edge cases
+
+- **User model without `hasPermissionTo`**: the hook returns `null` immediately, so non-RBAC users (e.g. admin accounts on a separate model) fall through to standard authorization.
+- **Empty permissions table**: the cache resolves to an empty array; every check falls through to policies.
+- **Race condition during permission creation**: if a new permission is created and a Gate check fires before the cache invalidator runs, the check falls through to policies. The next request picks up the fresh cache. This window is microseconds in normal apps; if it matters for your use case, call `Cache::tags('rbac')->flush()` manually after the create.

--- a/docs/usage/gate-integration.md
+++ b/docs/usage/gate-integration.md
@@ -89,7 +89,7 @@ See [Caching](../advanced/caching.md) for tuning.
 - **Race condition during permission creation**: if a new permission is created and a Gate check fires before the cache invalidator runs, the check falls through to policies. The next request picks up the fresh cache. This window is microseconds in normal apps; if it matters for your use case, invalidate manually after the create — conditionally on the cache driver:
 
   ```php
-  if ( Cache::getStore() instanceof Illuminate\Cache\TaggableStore ) {
+  if ( Cache::getStore() instanceof \Illuminate\Cache\TaggableStore ) {
       Cache::tags( config( 'artisanpack.rbac.cache.tag' ) )->flush();
   } else {
       Cache::forget( 'rbac_permission_names' );

--- a/docs/usage/gate-integration.md
+++ b/docs/usage/gate-integration.md
@@ -86,4 +86,12 @@ See [Caching](../advanced/caching.md) for tuning.
 
 - **User model without `hasPermissionTo`**: the hook returns `null` immediately, so non-RBAC users (e.g. admin accounts on a separate model) fall through to standard authorization.
 - **Empty permissions table**: the cache resolves to an empty array; every check falls through to policies.
-- **Race condition during permission creation**: if a new permission is created and a Gate check fires before the cache invalidator runs, the check falls through to policies. The next request picks up the fresh cache. This window is microseconds in normal apps; if it matters for your use case, call `Cache::tags('rbac')->flush()` manually after the create.
+- **Race condition during permission creation**: if a new permission is created and a Gate check fires before the cache invalidator runs, the check falls through to policies. The next request picks up the fresh cache. This window is microseconds in normal apps; if it matters for your use case, invalidate manually after the create — conditionally on the cache driver:
+
+  ```php
+  if ( Cache::getStore() instanceof Illuminate\Cache\TaggableStore ) {
+      Cache::tags( config( 'artisanpack.rbac.cache.tag' ) )->flush();
+  } else {
+      Cache::forget( 'rbac_permission_names' );
+  }
+  ```

--- a/docs/usage/middleware.md
+++ b/docs/usage/middleware.md
@@ -1,0 +1,78 @@
+---
+title: Middleware
+---
+
+# Middleware
+
+The service provider aliases `permission` to `ArtisanPackUI\Rbac\Http\Middleware\CheckPermission`. Apply it to any route that requires one or more permissions.
+
+## Single permission
+
+```php
+Route::get('/posts/{post}/publish', PublishController::class)
+    ->middleware('permission:posts.publish');
+```
+
+## Multiple permissions (OR)
+
+Comma-separate permissions to require **any** of them:
+
+```php
+Route::get('/admin', AdminController::class)
+    ->middleware('permission:admin.dashboard,admin.metrics');
+```
+
+The user only needs one of `admin.dashboard` or `admin.metrics` to proceed.
+
+## Behaviour
+
+| State | HTTP response |
+|---|---|
+| Unauthenticated (guest) | `401 Unauthorized` |
+| Authenticated, has one of the listed permissions | passes to controller (`200` or whatever the controller returns) |
+| Authenticated, has none of the listed permissions | `403 Forbidden` |
+
+Both abort codes use Laravel's default `abort()` helper, so your application's normal 401 / 403 error views render as expected.
+
+## Implementation reference
+
+```php
+class CheckPermission
+{
+    public function handle(Request $request, Closure $next, string ...$permissions)
+    {
+        if (Auth::guest()) {
+            abort(401);
+        }
+
+        $user = Auth::user();
+
+        foreach ($permissions as $permission) {
+            if ($user->can($permission)) {
+                return $next($request);
+            }
+        }
+
+        abort(403);
+    }
+}
+```
+
+The middleware delegates to `$user->can()`, which routes through the Gate integration and ultimately calls `HasPermissions::hasPermissionTo()`. So permissions inherited via the role hierarchy are honoured here.
+
+## When to use this vs other patterns
+
+- **Use the middleware** for route-level gating where a missing permission should produce an HTTP 403.
+- **Use `@permission` Blade directives** for view-level gating where a missing permission should hide UI elements.
+- **Use `$user->can()` / `Gate::allows()`** in controllers when the response depends on the permission outcome (e.g. show different fields, branch behaviour).
+- **Use Policies** when authorization logic involves the resource (e.g. "user can edit this post only if they authored it"). The Gate integration composes cleanly with policies — RBAC handles broad capabilities, policies handle per-resource rules.
+
+## "AND" semantics
+
+The middleware is OR-by-design. If you need AND semantics (user must hold every listed permission), apply the middleware multiple times:
+
+```php
+Route::middleware(['permission:admin.dashboard', 'permission:admin.metrics']);
+```
+
+Or implement a custom middleware that calls `$user->hasPermissionTo()` for each requirement.

--- a/docs/usage/permissions.md
+++ b/docs/usage/permissions.md
@@ -1,0 +1,84 @@
+---
+title: Permissions
+---
+
+# Permissions
+
+`ArtisanPackUI\Rbac\Models\Permission` is a standard Eloquent model representing a single, granular capability.
+
+## Schema
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | unique |
+| `slug` | string | unique; auto-derived from `name` via `Str::slug()` if not provided |
+| `description` | string \| null | |
+| `timestamps` | datetime | |
+
+## Relationships
+
+- `roles()` → `BelongsToMany Role`
+
+## Creating
+
+```php
+use ArtisanPackUI\Rbac\Models\Permission;
+
+$publish = Permission::create([
+    'name'        => 'posts.publish',
+    'description' => 'Publish blog posts',
+]);
+```
+
+The auto-slug runs `Str::slug()` on the name. `'posts.publish'` becomes `'postspublish'` — if you want dot-separated slugs preserved, set `slug` explicitly:
+
+```php
+Permission::create(['name' => 'posts.publish', 'slug' => 'posts.publish']);
+```
+
+## Naming conventions
+
+Two common conventions both work well:
+
+- **Dotted resource notation** — `posts.publish`, `users.delete`, `admin.dashboard`
+- **Action-first** — `publish-posts`, `delete-users`, `view-admin-dashboard`
+
+Use whichever you prefer; the package treats permission names as opaque strings. Whatever you pick, supply an explicit `slug` to keep the lookup key clean.
+
+## Slug lookup
+
+```php
+Permission::findBySlug('posts.publish');
+Permission::whereSlug('posts.publish')->first();
+```
+
+`hasPermissionTo('posts.publish')` and the Gate integration both match against either `name` or `slug`.
+
+## Attaching to roles
+
+Permissions are attached to roles (not directly to users). To grant a user a permission, attach it to a role they hold:
+
+```php
+$editor->permissions()->attach($publish);
+```
+
+A user can then check the permission via:
+
+```php
+$user->hasPermissionTo('posts.publish');
+$user->can('posts.publish');
+```
+
+…both of which recursively resolve through the role hierarchy.
+
+## Cascading deletes
+
+`Permission::delete()` detaches the permission from all roles before the row is removed.
+
+## Collision detection
+
+`Permission::save()` will throw if the supplied name or slug collides with another row's value in the **opposite** column. Same protection as `Role::save()`.
+
+## Cache invalidation
+
+Creating, updating, or deleting a permission flushes the `rbac_permission_names` cache via `PermissionObserver`, so the Gate `before` fast-path picks up the change on the next request. See [Caching](../advanced/caching.md) for details.

--- a/docs/usage/roles.md
+++ b/docs/usage/roles.md
@@ -1,0 +1,85 @@
+---
+title: Roles
+---
+
+# Roles
+
+`ArtisanPackUI\Rbac\Models\Role` is a standard Eloquent model with role-hierarchy support.
+
+## Schema
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | unique |
+| `slug` | string | unique; auto-derived from `name` via `Str::slug()` if not provided |
+| `description` | string \| null | |
+| `parent_id` | int \| null | foreign key to `roles.id`; `set null` on parent delete |
+| `timestamps` | datetime | |
+
+## Relationships
+
+- `permissions()` → `BelongsToMany Permission`
+- `users()` → `BelongsToMany` against `config('auth.providers.users.model')`
+- `parent()` → `BelongsTo Role`
+- `children()` → `HasMany Role`
+
+## Creating
+
+```php
+use ArtisanPackUI\Rbac\Models\Role;
+
+$editor = Role::create([
+    'name'        => 'Editor',
+    // 'slug' is auto-derived to 'editor'
+    'description' => 'Can publish and edit content',
+]);
+```
+
+Supplying an explicit slug overrides the auto-derivation:
+
+```php
+Role::create(['name' => 'Editor', 'slug' => 'content-editor']);
+```
+
+## Hierarchy
+
+Set `parent_id` to nest roles. Permissions resolve recursively up the chain via `HasPermissions::hasPermissionTo()`.
+
+```php
+$admin  = Role::create(['name' => 'admin']);
+$editor = Role::create(['name' => 'editor', 'parent_id' => $admin->id]);
+
+$editor->parent;    // admin Role
+$admin->children;   // collection containing editor
+```
+
+A user with the `editor` role will resolve to the union of `editor`'s direct permissions plus all of `admin`'s permissions (and grandparents, recursively).
+
+When a role is deleted, its `children` have `parent_id` set to `null` rather than being cascaded.
+
+## Slug lookup
+
+```php
+Role::findBySlug('editor');                  // ?Role
+Role::whereSlug('editor')->first();          // ?Role (via scope)
+```
+
+`hasRole('editor')` and `assignRole('editor')` (from the `HasRoles` trait) both match against either `name` or `slug`.
+
+## Attaching permissions
+
+```php
+$editor->permissions()->attach($publishPermission);
+$editor->permissions()->sync([$publish->id, $draft->id]);
+$editor->permissions()->detach($draftPermission);
+```
+
+Standard Eloquent BelongsToMany — no package-specific behaviour. Sync clears the permission cache automatically via the observer (see [Caching](../advanced/caching.md)).
+
+## Cascading deletes
+
+`Role::delete()` detaches the role's permissions and nulls `parent_id` on its children before the row is removed. This avoids dangling pivot rows and avoids orphaned children.
+
+## Collision detection
+
+`Role::save()` will throw if the supplied name or slug collides with another row's value in the **opposite** column (e.g. saving `name: 'editor'` when an existing row has `slug: 'editor'`). This prevents subtle lookup ambiguity in slug-based helpers.

--- a/docs/usage/user-traits.md
+++ b/docs/usage/user-traits.md
@@ -1,0 +1,80 @@
+---
+title: User Traits
+---
+
+# User Traits
+
+Two traits live in `ArtisanPackUI\Rbac\Concerns`. Apply both to your User model.
+
+```php
+use ArtisanPackUI\Rbac\Concerns\HasPermissions;
+use ArtisanPackUI\Rbac\Concerns\HasRoles;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    use HasPermissions;
+    use HasRoles;
+}
+```
+
+## `HasRoles`
+
+Adds the `roles()` relationship plus assignment helpers.
+
+```php
+$user->roles;                           // Collection<Role>
+$user->hasRole('admin');                // string, Role, or Collection<Role|string>
+$user->hasRole($adminRole);
+$user->hasRole(collect(['admin', 'editor']));  // true if user holds ANY listed role
+
+$user->assignRole('admin');             // idempotent; no-op for unknown role slugs
+$user->assignRole($adminRole);
+$user->removeRole('admin');
+```
+
+### Events
+
+`assignRole()` and `removeRole()` dispatch:
+
+- `rbac.user.role_assigned` (user, role)
+- `rbac.user.role_removed` (user, role)
+
+These are dispatched directly from the trait because Laravel does not fire Eloquent events for pivot operations. See [Events](../advanced/events.md) for the full event reference.
+
+### Idempotency
+
+`assignRole('admin')` on a user who already has the `admin` role is a no-op (no duplicate pivot row, no extra event). Same for `removeRole()` against a role the user doesn't hold.
+
+If `assignRole()` receives a role name / slug that doesn't exist, it silently no-ops rather than throwing. This is intentional for the Artisan commands' UX — pass the unresolved role through your own validation if you need stricter handling.
+
+## `HasPermissions`
+
+Resolves the user's effective permission set by walking the role hierarchy. Requires `HasRoles` to be present on the same model.
+
+```php
+$user->hasPermissionTo('posts.publish');   // bool
+$user->hasPermission('posts.publish');     // alias of hasPermissionTo
+$user->flushPermissionCache();             // call after manual pivot mutations
+```
+
+### Resolution algorithm
+
+1. Load the user's direct roles via `HasRoles::roles()`.
+2. For each role, walk up the `parent` chain collecting permissions at each level.
+3. Union the resulting permission collection and cache it under a per-user cache key for `artisanpack.rbac.cache.user_permissions_ttl` seconds (default 60).
+4. Return `true` if either the permission's `name` or `slug` matches the supplied string.
+
+### Manual cache invalidation
+
+The cache is invalidated automatically when:
+
+- A `Role` or `Permission` row is created / updated / deleted (via observers).
+
+It is **not** invalidated when you mutate pivot tables directly (e.g. `$user->roles()->attach($roleId)` without going through `assignRole`). In those cases, call `$user->flushPermissionCache()` yourself.
+
+## Combining the traits
+
+`HasRoles` works standalone if you only need role assignment without permission resolution. But `HasPermissions` depends on `HasRoles` to know which roles to resolve permissions through, so it should always be paired.
+
+Order in the `use` block doesn't matter — they don't share method names.

--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -1,6 +1,17 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * HasPermissions trait.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Concerns;
 
@@ -18,62 +29,62 @@ use Illuminate\Support\Facades\Cache;
  */
 trait HasPermissions
 {
-    public function hasPermissionTo(string $permission): bool
+    public function hasPermissionTo( string $permission ): bool
     {
         $permissions = $this->resolvePermissions();
 
         // Prefer name match; fall back to slug. This avoids ambiguity
         // when one row's name happens to equal another row's slug.
-        if ($permissions->contains('name', $permission)) {
+        if ( $permissions->contains( 'name', $permission ) ) {
             return true;
         }
 
-        return $permissions->contains('slug', $permission);
+        return $permissions->contains( 'slug', $permission );
     }
 
     /**
      * Backwards-compatible alias retained for callers that still use the
      * pre-extraction method name.
      */
-    public function hasPermission(string $permission): bool
+    public function hasPermission( string $permission ): bool
     {
-        return $this->hasPermissionTo($permission);
+        return $this->hasPermissionTo( $permission );
     }
 
     public function flushPermissionCache(): void
     {
         $cacheKey = $this->permissionCacheKey();
 
-        if ($this->cacheSupportsTagging()) {
-            Cache::tags([config('artisanpack.rbac.cache.tag', 'rbac')])->forget($cacheKey);
+        if ( $this->cacheSupportsTagging() ) {
+            Cache::tags( [config( 'artisanpack.rbac.cache.tag', 'rbac' )] )->forget( $cacheKey );
 
             return;
         }
 
-        Cache::forget($cacheKey);
+        Cache::forget( $cacheKey );
     }
 
     protected function resolvePermissions(): Collection
     {
         $cacheKey = $this->permissionCacheKey();
-        $ttl = (int) config('artisanpack.rbac.cache.user_permissions_ttl', 60);
-        $loader = fn () => $this->loadAllPermissions();
+        $ttl      = (int) config( 'artisanpack.rbac.cache.user_permissions_ttl', 60 );
+        $loader   = fn () => $this->loadAllPermissions();
 
-        if ($this->cacheSupportsTagging()) {
-            return Cache::tags([config('artisanpack.rbac.cache.tag', 'rbac')])
-                ->remember($cacheKey, $ttl, $loader);
+        if ( $this->cacheSupportsTagging() ) {
+            return Cache::tags( [config( 'artisanpack.rbac.cache.tag', 'rbac' )] )
+                ->remember( $cacheKey, $ttl, $loader );
         }
 
-        return Cache::remember($cacheKey, $ttl, $loader);
+        return Cache::remember( $cacheKey, $ttl, $loader );
     }
 
     protected function loadAllPermissions(): Collection
     {
         $all = collect();
 
-        $this->roles->each(function ($role) use (&$all): void {
-            $all = $all->merge($this->collectPermissionsForRole($role));
-        });
+        $this->roles->each( function ( $role ) use ( &$all ): void {
+            $all = $all->merge( $this->collectPermissionsForRole( $role ) );
+        } );
 
         return $all;
     }
@@ -81,17 +92,17 @@ trait HasPermissions
     /**
      * @param  array<int, int>  $visited
      */
-    protected function collectPermissionsForRole(Role $role, array $visited = []): Collection
+    protected function collectPermissionsForRole( Role $role, array $visited = [] ): Collection
     {
-        if (in_array($role->getKey(), $visited, true)) {
+        if ( in_array( $role->getKey(), $visited, true ) ) {
             return collect();
         }
 
-        $visited[] = $role->getKey();
+        $visited[]   = $role->getKey();
         $permissions = $role->permissions;
 
-        if ($role->parent) {
-            $permissions = $permissions->merge($this->collectPermissionsForRole($role->parent, $visited));
+        if ( $role->parent ) {
+            $permissions = $permissions->merge( $this->collectPermissionsForRole( $role->parent, $visited ) );
         }
 
         return $permissions;
@@ -104,6 +115,6 @@ trait HasPermissions
 
     protected function permissionCacheKey(): string
     {
-        return 'permissions_for_user_'.$this->getKey();
+        return 'permissions_for_user_' . $this->getKey();
     }
 }

--- a/src/Concerns/HasRoles.php
+++ b/src/Concerns/HasRoles.php
@@ -124,6 +124,6 @@ trait HasRoles
         // orWhere so a `name === other-row's-slug` collision can't return
         // the wrong row.
         return $model::query()->where( 'name', $role )->first()
-            ?? $model::query()->where( 'slug', $role)->first();
+            ?? $model::query()->where( 'slug', $role )->first();
     }
 }

--- a/src/Concerns/HasRoles.php
+++ b/src/Concerns/HasRoles.php
@@ -1,6 +1,17 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * HasRoles trait.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Concerns;
 
@@ -29,37 +40,37 @@ trait HasRoles
         );
     }
 
-    public function hasRole(Role|string|Collection $role): bool
+    public function hasRole( Role|string|Collection $role ): bool
     {
-        if (is_string($role)) {
+        if ( is_string( $role ) ) {
             // Prefer name match; fall back to slug. This avoids ambiguity
             // when one row's name happens to equal another row's slug.
-            if ($this->roles->contains('name', $role)) {
+            if ( $this->roles->contains( 'name', $role ) ) {
                 return true;
             }
 
-            return $this->roles->contains('slug', $role);
+            return $this->roles->contains( 'slug', $role );
         }
 
-        if ($role instanceof Role) {
-            return $this->roles->contains('id', $role->getKey());
+        if ( $role instanceof Role ) {
+            return $this->roles->contains( 'id', $role->getKey() );
         }
 
         $incomingIds = $role->map->getKey()->all();
-        $currentIds = $this->roles->map->getKey()->all();
+        $currentIds  = $this->roles->map->getKey()->all();
 
-        return count(array_intersect($incomingIds, $currentIds)) > 0;
+        return count( array_intersect( $incomingIds, $currentIds ) ) > 0;
     }
 
-    public function assignRole(Role|string $role): static
+    public function assignRole( Role|string $role ): static
     {
-        $resolved = $this->resolveRoleInstance($role);
+        $resolved = $this->resolveRoleInstance( $role );
 
-        if ($resolved !== null) {
-            $this->roles()->syncWithoutDetaching([$resolved->getKey()]);
-            Event::dispatch('rbac.user.role_assigned', [$this, $resolved]);
+        if ( null !== $resolved ) {
+            $this->roles()->syncWithoutDetaching( [$resolved->getKey()] );
+            Event::dispatch( 'rbac.user.role_assigned', [$this, $resolved] );
 
-            if (method_exists($this, 'flushPermissionCache')) {
+            if ( method_exists( $this, 'flushPermissionCache' ) ) {
                 $this->flushPermissionCache();
             }
         }
@@ -67,15 +78,15 @@ trait HasRoles
         return $this;
     }
 
-    public function removeRole(Role|string $role): static
+    public function removeRole( Role|string $role ): static
     {
-        $resolved = $this->resolveRoleInstance($role);
+        $resolved = $this->resolveRoleInstance( $role );
 
-        if ($resolved !== null) {
-            $this->roles()->detach($resolved->getKey());
-            Event::dispatch('rbac.user.role_removed', [$this, $resolved]);
+        if ( null !== $resolved ) {
+            $this->roles()->detach( $resolved->getKey() );
+            Event::dispatch( 'rbac.user.role_removed', [$this, $resolved] );
 
-            if (method_exists($this, 'flushPermissionCache')) {
+            if ( method_exists( $this, 'flushPermissionCache' ) ) {
                 $this->flushPermissionCache();
             }
         }
@@ -85,12 +96,12 @@ trait HasRoles
 
     protected function getRoleUserPivotTable(): string
     {
-        return config('artisanpack.rbac.tables.role_user', 'role_user');
+        return config( 'artisanpack.rbac.tables.role_user', 'role_user' );
     }
 
     protected function getRoleUserForeignKey(): string
     {
-        return config('artisanpack.rbac.foreign_keys.user', 'user_id');
+        return config( 'artisanpack.rbac.foreign_keys.user', 'user_id' );
     }
 
     /**
@@ -98,12 +109,12 @@ trait HasRoles
      */
     protected function resolveRoleModel(): string
     {
-        return config('artisanpack.rbac.models.role', Role::class);
+        return config( 'artisanpack.rbac.models.role', Role::class );
     }
 
-    protected function resolveRoleInstance(Role|string $role): ?Role
+    protected function resolveRoleInstance( Role|string $role ): ?Role
     {
-        if ($role instanceof Role) {
+        if ( $role instanceof Role ) {
             return $role;
         }
 
@@ -112,7 +123,7 @@ trait HasRoles
         // Prefer name match; fall back to slug. Two queries instead of an
         // orWhere so a `name === other-row's-slug` collision can't return
         // the wrong row.
-        return $model::query()->where('name', $role)->first()
-            ?? $model::query()->where('slug', $role)->first();
+        return $model::query()->where( 'name', $role )->first()
+            ?? $model::query()->where( 'slug', $role)->first();
     }
 }

--- a/src/Console/Commands/AssignRole.php
+++ b/src/Console/Commands/AssignRole.php
@@ -1,6 +1,17 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * `user:assign-role` Artisan command.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Console\Commands;
 
@@ -9,6 +20,12 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
 
+/**
+ * Assigns a role to a user. Idempotent — re-assigning a role the user
+ * already holds is a no-op (no duplicate pivot row, no event).
+ *
+ * @since 1.0.0
+ */
 class AssignRole extends Command
 {
     protected $signature = 'user:assign-role {user : The user ID, email, or username} {role : The role name or slug}';
@@ -17,37 +34,37 @@ class AssignRole extends Command
 
     public function handle(): int
     {
-        $userModel = config('auth.providers.users.model');
-        $roleModel = config('artisanpack.rbac.models.role', Role::class);
+        $userModel = config( 'auth.providers.users.model' );
+        $roleModel = config( 'artisanpack.rbac.models.role', Role::class );
 
-        $userArgument = $this->argument('user');
-        $roleArgument = $this->argument('role');
+        $userArgument = $this->argument( 'user' );
+        $roleArgument = $this->argument( 'role' );
         // Name first, slug fallback — two queries so a name/slug collision
         // can't resolve to the wrong row.
-        $role = $roleModel::where('name', $roleArgument)->first()
-            ?? $roleModel::where('slug', $roleArgument)->first();
+        $role = $roleModel::where( 'name', $roleArgument )->first()
+            ?? $roleModel::where( 'slug', $roleArgument )->first();
 
-        $user = $this->resolveUser($userModel, $userArgument);
+        $user = $this->resolveUser( $userModel, $userArgument );
 
-        if (! $user) {
-            $this->error('User not found.');
-
-            return self::FAILURE;
-        }
-
-        if (! $role) {
-            $this->error('Role not found.');
+        if ( ! $user ) {
+            $this->error( 'User not found.' );
 
             return self::FAILURE;
         }
 
-        $user->roles()->syncWithoutDetaching([$role->getKey()]);
+        if ( ! $role ) {
+            $this->error( 'Role not found.' );
 
-        if (method_exists($user, 'flushPermissionCache')) {
+            return self::FAILURE;
+        }
+
+        $user->roles()->syncWithoutDetaching( [$role->getKey()] );
+
+        if ( method_exists( $user, 'flushPermissionCache' ) ) {
             $user->flushPermissionCache();
         }
 
-        $this->info("Role `{$role->name}` assigned to user `{$user->name}` successfully.");
+        $this->info( "Role `{$role->name}` assigned to user `{$user->name}` successfully." );
 
         return self::SUCCESS;
     }
@@ -59,24 +76,24 @@ class AssignRole extends Command
      *
      * @param  class-string<Model>  $userModel
      */
-    protected function resolveUser(string $userModel, string $identifier)
+    protected function resolveUser( string $userModel, string $identifier )
     {
-        if (is_numeric($identifier)) {
-            return $userModel::find($identifier);
+        if ( is_numeric( $identifier ) ) {
+            return $userModel::find( $identifier );
         }
 
-        $table = (new $userModel)->getTable();
-        $fields = (array) config('artisanpack.rbac.user_lookup_fields', ['email']);
+        $table  = (new $userModel)->getTable();
+        $fields = (array) config( 'artisanpack.rbac.user_lookup_fields', ['email'] );
 
         $query = $userModel::query();
-        $any = false;
+        $any   = false;
 
-        foreach ($fields as $field) {
-            if (! Schema::hasColumn($table, $field)) {
+        foreach ( $fields as $field ) {
+            if ( ! Schema::hasColumn( $table, $field ) ) {
                 continue;
             }
 
-            $query->orWhere($field, $identifier);
+            $query->orWhere( $field, $identifier );
             $any = true;
         }
 

--- a/src/Console/Commands/CreatePermission.php
+++ b/src/Console/Commands/CreatePermission.php
@@ -1,12 +1,30 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * `permission:create` Artisan command.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Console\Commands;
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use Illuminate\Console\Command;
 
+/**
+ * Creates a permission row. Slug is auto-derived from `name` unless
+ * an explicit `--slug` is supplied. Permission creation flushes the
+ * Gate `before` permission-names cache via the observer.
+ *
+ * @since 1.0.0
+ */
 class CreatePermission extends Command
 {
     protected $signature = 'permission:create {name} {--slug=} {--description=}';
@@ -15,25 +33,25 @@ class CreatePermission extends Command
 
     public function handle(): int
     {
-        $model = config('artisanpack.rbac.models.permission', Permission::class);
+        $model = config( 'artisanpack.rbac.models.permission', Permission::class );
 
         $payload = array_map(
-            fn ($value) => is_string($value) ? trim($value) : $value,
+            fn ( $value ) => is_string( $value ) ? trim( $value ) : $value,
             [
-                'name' => $this->argument('name'),
-                'slug' => $this->option('slug'),
-                'description' => $this->option('description'),
+                'name'        => $this->argument( 'name' ),
+                'slug'        => $this->option( 'slug' ),
+                'description' => $this->option( 'description' ),
             ],
         );
 
         $permission = $model::create(
             array_filter(
                 $payload,
-                fn ($value) => $value !== null && $value !== '',
+                fn ( $value ) => null !== $value && '' !== $value,
             ),
         );
 
-        $this->info("Permission `{$permission->name}` created successfully.");
+        $this->info( "Permission `{$permission->name}` created successfully." );
 
         return self::SUCCESS;
     }

--- a/src/Console/Commands/CreateRole.php
+++ b/src/Console/Commands/CreateRole.php
@@ -1,12 +1,30 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * `role:create` Artisan command.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Console\Commands;
 
 use ArtisanPackUI\Rbac\Models\Role;
 use Illuminate\Console\Command;
 
+/**
+ * Creates a role row. Slug is auto-derived from `name` unless an
+ * explicit `--slug` is supplied. Hierarchy is configured via
+ * `parent_id` post-creation, not via this command.
+ *
+ * @since 1.0.0
+ */
 class CreateRole extends Command
 {
     protected $signature = 'role:create {name} {--slug=} {--description=}';
@@ -15,25 +33,25 @@ class CreateRole extends Command
 
     public function handle(): int
     {
-        $model = config('artisanpack.rbac.models.role', Role::class);
+        $model = config( 'artisanpack.rbac.models.role', Role::class );
 
         $payload = array_map(
-            fn ($value) => is_string($value) ? trim($value) : $value,
+            fn ( $value ) => is_string( $value ) ? trim( $value ) : $value,
             [
-                'name' => $this->argument('name'),
-                'slug' => $this->option('slug'),
-                'description' => $this->option('description'),
+                'name'        => $this->argument( 'name' ),
+                'slug'        => $this->option( 'slug' ),
+                'description' => $this->option( 'description' ),
             ],
         );
 
         $role = $model::create(
             array_filter(
                 $payload,
-                fn ($value) => $value !== null && $value !== '',
+                fn ( $value ) => null !== $value && '' !== $value,
             ),
         );
 
-        $this->info("Role `{$role->name}` created successfully.");
+        $this->info( "Role `{$role->name}` created successfully." );
 
         return self::SUCCESS;
     }

--- a/src/Console/Commands/RevokeRole.php
+++ b/src/Console/Commands/RevokeRole.php
@@ -1,6 +1,17 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * `user:revoke-role` Artisan command.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Console\Commands;
 
@@ -9,6 +20,12 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
 
+/**
+ * Revokes a role from a user. Idempotent — revoking a role the user
+ * doesn't hold is a no-op (no event fires).
+ *
+ * @since 1.0.0
+ */
 class RevokeRole extends Command
 {
     protected $signature = 'user:revoke-role {user : The user ID, email, or username} {role : The role name or slug}';
@@ -17,37 +34,37 @@ class RevokeRole extends Command
 
     public function handle(): int
     {
-        $userModel = config('auth.providers.users.model');
-        $roleModel = config('artisanpack.rbac.models.role', Role::class);
+        $userModel = config( 'auth.providers.users.model' );
+        $roleModel = config( 'artisanpack.rbac.models.role', Role::class );
 
-        $userArgument = $this->argument('user');
-        $roleArgument = $this->argument('role');
+        $userArgument = $this->argument( 'user' );
+        $roleArgument = $this->argument( 'role' );
         // Name first, slug fallback — two queries so a name/slug collision
         // can't resolve to the wrong row.
-        $role = $roleModel::where('name', $roleArgument)->first()
-            ?? $roleModel::where('slug', $roleArgument)->first();
+        $role = $roleModel::where( 'name', $roleArgument )->first()
+            ?? $roleModel::where( 'slug', $roleArgument )->first();
 
-        $user = $this->resolveUser($userModel, $userArgument);
+        $user = $this->resolveUser( $userModel, $userArgument );
 
-        if (! $user) {
-            $this->error('User not found.');
-
-            return self::FAILURE;
-        }
-
-        if (! $role) {
-            $this->error('Role not found.');
+        if ( ! $user ) {
+            $this->error( 'User not found.' );
 
             return self::FAILURE;
         }
 
-        $user->roles()->detach($role->getKey());
+        if ( ! $role ) {
+            $this->error( 'Role not found.' );
 
-        if (method_exists($user, 'flushPermissionCache')) {
+            return self::FAILURE;
+        }
+
+        $user->roles()->detach( $role->getKey() );
+
+        if ( method_exists( $user, 'flushPermissionCache' ) ) {
             $user->flushPermissionCache();
         }
 
-        $this->info("Role `{$role->name}` revoked from user `{$user->name}` successfully.");
+        $this->info( "Role `{$role->name}` revoked from user `{$user->name}` successfully." );
 
         return self::SUCCESS;
     }
@@ -59,24 +76,24 @@ class RevokeRole extends Command
      *
      * @param  class-string<Model>  $userModel
      */
-    protected function resolveUser(string $userModel, string $identifier)
+    protected function resolveUser( string $userModel, string $identifier )
     {
-        if (is_numeric($identifier)) {
-            return $userModel::find($identifier);
+        if ( is_numeric( $identifier ) ) {
+            return $userModel::find( $identifier );
         }
 
-        $table = (new $userModel)->getTable();
-        $fields = (array) config('artisanpack.rbac.user_lookup_fields', ['email']);
+        $table  = (new $userModel)->getTable();
+        $fields = (array) config( 'artisanpack.rbac.user_lookup_fields', ['email'] );
 
         $query = $userModel::query();
-        $any = false;
+        $any   = false;
 
-        foreach ($fields as $field) {
-            if (! Schema::hasColumn($table, $field)) {
+        foreach ( $fields as $field ) {
+            if ( ! Schema::hasColumn( $table, $field ) ) {
                 continue;
             }
 
-            $query->orWhere($field, $identifier);
+            $query->orWhere( $field, $identifier );
             $any = true;
         }
 

--- a/src/Facades/Rbac.php
+++ b/src/Facades/Rbac.php
@@ -1,15 +1,17 @@
 <?php
 
 /**
- * Rbac Facade.
+ * Rbac Facade — static accessor for the Rbac class.
  *
- * Provides static access to the Rbac class.
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
  *
+ * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Facades;
 

--- a/src/Http/Middleware/CheckPermission.php
+++ b/src/Http/Middleware/CheckPermission.php
@@ -44,6 +44,6 @@ class CheckPermission
             }
         }
 
-        abort( 403);
+        abort( 403 );
     }
 }

--- a/src/Http/Middleware/CheckPermission.php
+++ b/src/Http/Middleware/CheckPermission.php
@@ -1,6 +1,17 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * CheckPermission route middleware.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Http\Middleware;
 
@@ -19,20 +30,20 @@ use Illuminate\Support\Facades\Auth;
  */
 class CheckPermission
 {
-    public function handle(Request $request, Closure $next, string ...$permissions)
+    public function handle( Request $request, Closure $next, string ...$permissions )
     {
-        if (Auth::guest()) {
-            abort(401);
+        if ( Auth::guest() ) {
+            abort( 401 );
         }
 
         $user = Auth::user();
 
-        foreach ($permissions as $permission) {
-            if ($user->can($permission)) {
-                return $next($request);
+        foreach ( $permissions as $permission ) {
+            if ( $user->can( $permission ) ) {
+                return $next( $request );
             }
         }
 
-        abort(403);
+        abort( 403);
     }
 }

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -106,7 +106,7 @@ class Permission extends Model
     {
         parent::boot();
 
-        static::deleting( function ( $permission): void {
+        static::deleting( function ( $permission ): void {
             $permission->roles()->detach();
         });
     }

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -1,6 +1,17 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * Permission Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Models;
 
@@ -8,6 +19,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 /**
  * Permission model — represents an atomic capability that can be granted
@@ -27,30 +39,30 @@ class Permission extends Model
     public function roles(): BelongsToMany
     {
         return $this->belongsToMany(
-            config('artisanpack.rbac.models.role', Role::class),
-            config('artisanpack.rbac.tables.permission_role', 'permission_role'),
+            config( 'artisanpack.rbac.models.role', Role::class ),
+            config( 'artisanpack.rbac.tables.permission_role', 'permission_role' ),
         );
     }
 
-    public function scopeWhereSlug(Builder $query, string $slug): Builder
+    public function scopeWhereSlug( Builder $query, string $slug ): Builder
     {
-        return $query->where('slug', $slug);
+        return $query->where( 'slug', $slug );
     }
 
-    public static function findBySlug(string $slug): ?static
+    public static function findBySlug( string $slug ): ?static
     {
-        return static::query()->where('slug', $slug)->first();
+        return static::query()->where( 'slug', $slug )->first();
     }
 
-    public function save(array $options = []): bool
+    public function save( array $options = [] ): bool
     {
-        if (empty($this->slug) && ! empty($this->name)) {
-            $this->slug = Str::slug($this->name);
+        if ( empty( $this->slug ) && ! empty( $this->name ) ) {
+            $this->slug = Str::slug( $this->name );
         }
 
         $this->guardAgainstNameSlugCollision();
 
-        return parent::save($options);
+        return parent::save( $options );
     }
 
     /**
@@ -61,32 +73,32 @@ class Permission extends Model
      */
     protected function guardAgainstNameSlugCollision(): void
     {
-        if (empty($this->name) || empty($this->slug)) {
+        if ( empty( $this->name ) || empty( $this->slug ) ) {
             return;
         }
 
         $key = $this->getKey();
 
         $collision = static::query()
-            ->where(function ($query): void {
-                $query->where('name', $this->slug)
-                    ->orWhere('slug', $this->name);
-            })
-            ->when($key !== null, fn ($query) => $query->where($this->getKeyName(), '!=', $key))
-            ->where(function ($query): void {
+            ->where( function ( $query ): void {
+                $query->where( 'name', $this->slug )
+                    ->orWhere( 'slug', $this->name );
+            } )
+            ->when( null !== $key, fn ( $query ) => $query->where( $this->getKeyName(), '!=', $key ) )
+            ->where( function ( $query ): void {
                 // Self-overlap (name === slug on this same row) is fine —
                 // it's the most common case post auto-derivation.
-                $query->where('name', '!=', $this->name)
-                    ->orWhere('slug', '!=', $this->slug);
-            })
+                $query->where( 'name', '!=', $this->name )
+                    ->orWhere( 'slug', '!=', $this->slug );
+            } )
             ->exists();
 
-        if ($collision) {
-            throw new \RuntimeException(sprintf(
+        if ( $collision ) {
+            throw new RuntimeException( sprintf(
                 'Permission name/slug collision: another row already uses "%s" or "%s" in the opposite column.',
                 $this->name,
                 $this->slug,
-            ));
+            ) );
         }
     }
 
@@ -94,7 +106,7 @@ class Permission extends Model
     {
         parent::boot();
 
-        static::deleting(function ($permission): void {
+        static::deleting( function ( $permission): void {
             $permission->roles()->detach();
         });
     }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -1,6 +1,17 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * Role Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Models;
 
@@ -10,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 /**
  * Role model — represents a named bundle of permissions optionally arranged
@@ -27,53 +39,53 @@ class Role extends Model
         'parent_id',
     ];
 
-    public function scopeWhereSlug(Builder $query, string $slug): Builder
+    public function scopeWhereSlug( Builder $query, string $slug ): Builder
     {
-        return $query->where('slug', $slug);
+        return $query->where( 'slug', $slug );
     }
 
-    public static function findBySlug(string $slug): ?static
+    public static function findBySlug( string $slug ): ?static
     {
-        return static::query()->where('slug', $slug)->first();
+        return static::query()->where( 'slug', $slug )->first();
     }
 
     public function permissions(): BelongsToMany
     {
         return $this->belongsToMany(
-            config('artisanpack.rbac.models.permission', Permission::class),
-            config('artisanpack.rbac.tables.permission_role', 'permission_role'),
+            config( 'artisanpack.rbac.models.permission', Permission::class ),
+            config( 'artisanpack.rbac.tables.permission_role', 'permission_role' ),
         );
     }
 
     public function users(): BelongsToMany
     {
         return $this->belongsToMany(
-            config('auth.providers.users.model'),
-            config('artisanpack.rbac.tables.role_user', 'role_user'),
+            config( 'auth.providers.users.model' ),
+            config( 'artisanpack.rbac.tables.role_user', 'role_user' ),
             'role_id',
-            config('artisanpack.rbac.foreign_keys.user', 'user_id'),
+            config( 'artisanpack.rbac.foreign_keys.user', 'user_id' ),
         );
     }
 
     public function parent(): BelongsTo
     {
-        return $this->belongsTo(static::class, 'parent_id');
+        return $this->belongsTo( static::class, 'parent_id' );
     }
 
     public function children(): HasMany
     {
-        return $this->hasMany(static::class, 'parent_id');
+        return $this->hasMany( static::class, 'parent_id' );
     }
 
-    public function save(array $options = []): bool
+    public function save( array $options = [] ): bool
     {
-        if (empty($this->slug) && ! empty($this->name)) {
-            $this->slug = Str::slug($this->name);
+        if ( empty( $this->slug ) && ! empty( $this->name ) ) {
+            $this->slug = Str::slug( $this->name );
         }
 
         $this->guardAgainstNameSlugCollision();
 
-        return parent::save($options);
+        return parent::save( $options );
     }
 
     /**
@@ -84,32 +96,32 @@ class Role extends Model
      */
     protected function guardAgainstNameSlugCollision(): void
     {
-        if (empty($this->name) || empty($this->slug)) {
+        if ( empty( $this->name ) || empty( $this->slug ) ) {
             return;
         }
 
         $key = $this->getKey();
 
         $collision = static::query()
-            ->where(function ($query): void {
-                $query->where('name', $this->slug)
-                    ->orWhere('slug', $this->name);
-            })
-            ->when($key !== null, fn ($query) => $query->where($this->getKeyName(), '!=', $key))
-            ->where(function ($query): void {
+            ->where( function ( $query ): void {
+                $query->where( 'name', $this->slug )
+                    ->orWhere( 'slug', $this->name );
+            } )
+            ->when( null !== $key, fn ( $query ) => $query->where( $this->getKeyName(), '!=', $key ) )
+            ->where( function ( $query ): void {
                 // Self-overlap (name === slug on this same row) is fine —
                 // it's the most common case post auto-derivation.
-                $query->where('name', '!=', $this->name)
-                    ->orWhere('slug', '!=', $this->slug);
-            })
+                $query->where( 'name', '!=', $this->name )
+                    ->orWhere( 'slug', '!=', $this->slug );
+            } )
             ->exists();
 
-        if ($collision) {
-            throw new \RuntimeException(sprintf(
+        if ( $collision ) {
+            throw new RuntimeException( sprintf(
                 'Role name/slug collision: another row already uses "%s" or "%s" in the opposite column.',
                 $this->name,
                 $this->slug,
-            ));
+            ) );
         }
     }
 
@@ -117,7 +129,7 @@ class Role extends Model
     {
         parent::boot();
 
-        static::deleting(function ($role): void {
+        static::deleting( function ( $role ): void {
             $role->permissions()->detach();
             $role->users()->detach();
         });

--- a/src/Observers/PermissionObserver.php
+++ b/src/Observers/PermissionObserver.php
@@ -1,6 +1,17 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * Permission Eloquent observer.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Observers;
 
@@ -15,12 +26,12 @@ use Illuminate\Support\Facades\Event;
  */
 class PermissionObserver
 {
-    public function created(Permission $permission): void
+    public function created( Permission $permission ): void
     {
-        Event::dispatch('rbac.permission.created', [$permission]);
+        Event::dispatch( 'rbac.permission.created', [$permission] );
     }
 
-    public function updated(Permission $permission): void
+    public function updated( Permission $permission ): void
     {
         Event::dispatch(
             'rbac.permission.updated',
@@ -28,8 +39,8 @@ class PermissionObserver
         );
     }
 
-    public function deleted(Permission $permission): void
+    public function deleted( Permission $permission ): void
     {
-        Event::dispatch('rbac.permission.deleted', [$permission]);
+        Event::dispatch( 'rbac.permission.deleted', [$permission] );
     }
 }

--- a/src/Observers/RoleObserver.php
+++ b/src/Observers/RoleObserver.php
@@ -1,6 +1,17 @@
 <?php
 
-declare(strict_types=1);
+/**
+ * Role Eloquent observer.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac\Observers;
 
@@ -18,18 +29,18 @@ use Illuminate\Support\Facades\Event;
  */
 class RoleObserver
 {
-    public function created(Role $role): void
+    public function created( Role $role ): void
     {
-        Event::dispatch('rbac.role.created', [$role]);
+        Event::dispatch( 'rbac.role.created', [$role] );
     }
 
-    public function updated(Role $role): void
+    public function updated( Role $role ): void
     {
-        Event::dispatch('rbac.role.updated', [$role, $role->getChanges(), $role->getOriginal()]);
+        Event::dispatch( 'rbac.role.updated', [$role, $role->getChanges(), $role->getOriginal()] );
     }
 
-    public function deleted(Role $role): void
+    public function deleted( Role $role ): void
     {
-        Event::dispatch('rbac.role.deleted', [$role]);
+        Event::dispatch( 'rbac.role.deleted', [$role] );
     }
 }

--- a/src/Rbac.php
+++ b/src/Rbac.php
@@ -1,16 +1,22 @@
 <?php
 
 /**
- * Main Rbac class.
+ * Main Rbac class — public entry point reserved for future API surface.
  *
- * This is the main class for the package, accessed via the 'rbac' helper
- * function or the Rbac facade.
+ * Accessed via the `rbac()` helper or the `Rbac` Facade. The class itself
+ * is intentionally empty today; the package's behaviour lives in models,
+ * traits, middleware, and the service provider. Add public API methods
+ * here as cross-cutting role / permission lookups emerge.
  *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac;
 

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -212,8 +212,8 @@ class RbacServiceProvider extends ServiceProvider
         $cacheKey = 'rbac_permission_names';
         $tag      = config( 'artisanpack.rbac.cache.tag', 'rbac' );
 
-        if ( Cache::getStore() instanceof TaggableStore) {
-            Cache::tags( [$tag])->forget( $cacheKey);
+        if ( Cache::getStore() instanceof TaggableStore ) {
+            Cache::tags( [$tag] )->forget( $cacheKey );
 
             return;
         }

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -7,13 +7,15 @@
  * middleware aliases, Artisan commands, Blade directives, and Gate
  * integration.
  *
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
  *
- * @author     Jacob Martella <me@jacobmartella.com>
+ * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Rbac;
 
@@ -48,13 +50,13 @@ class RbacServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/artisanpack/rbac.php',
+            __DIR__ . '/../config/artisanpack/rbac.php',
             'artisanpack.rbac',
         );
 
-        $this->app->singleton('rbac', function ($app) {
+        $this->app->singleton( 'rbac', function ( $app ) {
             return new Rbac;
-        });
+        } );
     }
 
     /**
@@ -66,12 +68,12 @@ class RbacServiceProvider extends ServiceProvider
     {
         $this->publishes(
             [
-                __DIR__.'/../config/artisanpack/rbac.php' => config_path('artisanpack/rbac.php'),
+                __DIR__ . '/../config/artisanpack/rbac.php' => config_path( 'artisanpack/rbac.php' ),
             ],
             'rbac-config',
         );
 
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
 
         $this->registerObservers();
         $this->registerMiddleware();
@@ -86,11 +88,11 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerObservers(): void
     {
-        $roleModel = config('artisanpack.rbac.models.role', Role::class);
-        $permissionModel = config('artisanpack.rbac.models.permission', Permission::class);
+        $roleModel       = config( 'artisanpack.rbac.models.role', Role::class );
+        $permissionModel = config( 'artisanpack.rbac.models.permission', Permission::class );
 
-        $roleModel::observe(RoleObserver::class);
-        $permissionModel::observe(PermissionObserver::class);
+        $roleModel::observe( RoleObserver::class );
+        $permissionModel::observe( PermissionObserver::class );
     }
 
     /**
@@ -98,7 +100,7 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerMiddleware(): void
     {
-        $this->app['router']->aliasMiddleware('permission', CheckPermission::class);
+        $this->app['router']->aliasMiddleware( 'permission', CheckPermission::class );
     }
 
     /**
@@ -106,7 +108,7 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerCommands(): void
     {
-        if (! $this->app->runningInConsole()) {
+        if ( ! $this->app->runningInConsole() ) {
             return;
         }
 
@@ -125,21 +127,21 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerBladeDirectives(): void
     {
-        Blade::directive('role', function ($role) {
+        Blade::directive( 'role', function ( $role ) {
             return "<?php if(auth()->check() && method_exists(auth()->user(), 'hasRole') && auth()->user()->hasRole({$role})): ?>";
-        });
+        } );
 
-        Blade::directive('endrole', function () {
+        Blade::directive( 'endrole', function () {
             return '<?php endif; ?>';
-        });
+        } );
 
-        Blade::directive('permission', function ($permission) {
+        Blade::directive( 'permission', function ( $permission ) {
             return "<?php if(auth()->check() && auth()->user()->can({$permission})): ?>";
-        });
+        } );
 
-        Blade::directive('endpermission', function () {
+        Blade::directive( 'endpermission', function () {
             return '<?php endif; ?>';
-        });
+        } );
     }
 
     /**
@@ -149,19 +151,19 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerGate(): void
     {
-        Gate::before(function ($user, $ability) {
-            if (! method_exists($user, 'hasPermissionTo')) {
+        Gate::before( function ( $user, $ability ) {
+            if ( ! method_exists( $user, 'hasPermissionTo' ) ) {
                 return null;
             }
 
             $permissionNames = $this->getCachedPermissionNames();
 
-            if (in_array($ability, $permissionNames, true)) {
-                return $user->hasPermissionTo($ability);
+            if ( in_array( $ability, $permissionNames, true ) ) {
+                return $user->hasPermissionTo( $ability );
             }
 
             return null;
-        });
+        } );
     }
 
     /**
@@ -170,11 +172,11 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerPermissionCacheInvalidators(): void
     {
-        $permissionModel = config('artisanpack.rbac.models.permission', Permission::class);
+        $permissionModel = config( 'artisanpack.rbac.models.permission', Permission::class );
 
-        $permissionModel::created(fn () => $this->flushPermissionNamesCache());
-        $permissionModel::updated(fn () => $this->flushPermissionNamesCache());
-        $permissionModel::deleted(fn () => $this->flushPermissionNamesCache());
+        $permissionModel::created( fn () => $this->flushPermissionNamesCache() );
+        $permissionModel::updated( fn () => $this->flushPermissionNamesCache() );
+        $permissionModel::deleted( fn () => $this->flushPermissionNamesCache() );
     }
 
     /**
@@ -184,22 +186,22 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function getCachedPermissionNames(): array
     {
-        $permissionModel = config('artisanpack.rbac.models.permission', Permission::class);
-        $cacheKey = 'rbac_permission_names';
-        $ttl = (int) config('artisanpack.rbac.cache.permission_names_ttl', 3600);
+        $permissionModel = config( 'artisanpack.rbac.models.permission', Permission::class );
+        $cacheKey        = 'rbac_permission_names';
+        $ttl             = (int) config( 'artisanpack.rbac.cache.permission_names_ttl', 3600 );
 
-        if (Cache::getStore() instanceof TaggableStore) {
-            return Cache::tags([config('artisanpack.rbac.cache.tag', 'rbac')])
-                ->remember($cacheKey, $ttl, fn () => array_values(array_unique(array_merge(
-                    $permissionModel::pluck('name')->toArray(),
-                    $permissionModel::pluck('slug')->toArray(),
-                ))));
+        if ( Cache::getStore() instanceof TaggableStore ) {
+            return Cache::tags( [config( 'artisanpack.rbac.cache.tag', 'rbac' )] )
+                ->remember( $cacheKey, $ttl, fn () => array_values( array_unique( array_merge(
+                    $permissionModel::pluck( 'name' )->toArray(),
+                    $permissionModel::pluck( 'slug' )->toArray(),
+                ) ) ) );
         }
 
-        return Cache::remember($cacheKey, $ttl, fn () => array_values(array_unique(array_merge(
-            $permissionModel::pluck('name')->toArray(),
-            $permissionModel::pluck('slug')->toArray(),
-        ))));
+        return Cache::remember( $cacheKey, $ttl, fn () => array_values( array_unique( array_merge(
+            $permissionModel::pluck( 'name' )->toArray(),
+            $permissionModel::pluck( 'slug' )->toArray(),
+        ) ) ) );
     }
 
     /**
@@ -208,14 +210,14 @@ class RbacServiceProvider extends ServiceProvider
     protected function flushPermissionNamesCache(): void
     {
         $cacheKey = 'rbac_permission_names';
-        $tag = config('artisanpack.rbac.cache.tag', 'rbac');
+        $tag      = config( 'artisanpack.rbac.cache.tag', 'rbac' );
 
-        if (Cache::getStore() instanceof TaggableStore) {
-            Cache::tags([$tag])->forget($cacheKey);
+        if ( Cache::getStore() instanceof TaggableStore) {
+            Cache::tags( [$tag])->forget( $cacheKey);
 
             return;
         }
 
-        Cache::forget($cacheKey);
+        Cache::forget( $cacheKey);
     }
 }

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -218,6 +218,6 @@ class RbacServiceProvider extends ServiceProvider
             return;
         }
 
-        Cache::forget( $cacheKey);
+        Cache::forget( $cacheKey );
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,16 +3,17 @@
 /**
  * Rbac helper functions.
  *
- * This file contains global helper functions for the Rbac package.
- * Add custom helper functions below.
+ * @package    ArtisanPack_UI
+ * @subpackage Rbac
  *
+ * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
 use ArtisanPackUI\Rbac\Rbac;
 
-if (! function_exists('rbac')) {
+if ( ! function_exists( 'rbac' ) ) {
     /**
      * Get the Rbac instance.
      *
@@ -20,7 +21,7 @@ if (! function_exists('rbac')) {
      */
     function rbac(): Rbac
     {
-        return app('rbac');
+        return app( 'rbac' );
     }
 }
 

--- a/tests/Feature/BladeDirectivesTest.php
+++ b/tests/Feature/BladeDirectivesTest.php
@@ -46,4 +46,4 @@ it( 'renders nothing for unauthenticated users in @permission blocks', function 
     $rendered = view()->file( __DIR__ . '/../views/permission-directive.blade.php' )->render();
 
     expect( $rendered )->not->toContain( 'User can edit articles' );
-});
+} );

--- a/tests/Feature/BladeDirectivesTest.php
+++ b/tests/Feature/BladeDirectivesTest.php
@@ -1,49 +1,49 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 use Tests\Models\TestUser;
 
-it('renders the @role block when the user has the role', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $user->roles()->attach(Role::create(['name' => 'admin']));
-    $this->actingAs($user);
+it( 'renders the @role block when the user has the role', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $user->roles()->attach( Role::create( ['name' => 'admin'] ) );
+    $this->actingAs( $user );
 
-    $rendered = view()->file(__DIR__.'/../views/role-directive.blade.php')->render();
+    $rendered = view()->file( __DIR__ . '/../views/role-directive.blade.php' )->render();
 
-    expect($rendered)->toContain('User is an admin');
-    expect($rendered)->not->toContain('User is a moderator');
-});
+    expect( $rendered )->toContain( 'User is an admin' );
+    expect( $rendered )->not->toContain( 'User is a moderator' );
+} );
 
-it('renders nothing for unauthenticated users in @role blocks', function (): void {
-    Role::create(['name' => 'admin']);
+it( 'renders nothing for unauthenticated users in @role blocks', function (): void {
+    Role::create( ['name' => 'admin'] );
 
-    $rendered = view()->file(__DIR__.'/../views/role-directive.blade.php')->render();
+    $rendered = view()->file( __DIR__ . '/../views/role-directive.blade.php' )->render();
 
-    expect($rendered)->not->toContain('User is an admin');
-    expect($rendered)->not->toContain('User is a moderator');
-});
+    expect( $rendered )->not->toContain( 'User is an admin' );
+    expect( $rendered )->not->toContain( 'User is a moderator' );
+} );
 
-it('renders the @permission block when the user has the permission', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'editor']);
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $role->permissions()->attach($permission);
-    $user->roles()->attach($role);
-    $this->actingAs($user);
+it( 'renders the @permission block when the user has the permission', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
+    $this->actingAs( $user );
 
-    $rendered = view()->file(__DIR__.'/../views/permission-directive.blade.php')->render();
+    $rendered = view()->file( __DIR__ . '/../views/permission-directive.blade.php' )->render();
 
-    expect($rendered)->toContain('User can edit articles');
-    expect($rendered)->not->toContain('User can delete articles');
-});
+    expect( $rendered )->toContain( 'User can edit articles' );
+    expect( $rendered )->not->toContain( 'User can delete articles' );
+} );
 
-it('renders nothing for unauthenticated users in @permission blocks', function (): void {
-    Permission::create(['name' => 'edit-articles']);
+it( 'renders nothing for unauthenticated users in @permission blocks', function (): void {
+    Permission::create( ['name' => 'edit-articles'] );
 
-    $rendered = view()->file(__DIR__.'/../views/permission-directive.blade.php')->render();
+    $rendered = view()->file( __DIR__ . '/../views/permission-directive.blade.php')->render();
 
-    expect($rendered)->not->toContain('User can edit articles');
+    expect( $rendered)->not->toContain( 'User can edit articles');
 });

--- a/tests/Feature/BladeDirectivesTest.php
+++ b/tests/Feature/BladeDirectivesTest.php
@@ -43,7 +43,7 @@ it( 'renders the @permission block when the user has the permission', function (
 it( 'renders nothing for unauthenticated users in @permission blocks', function (): void {
     Permission::create( ['name' => 'edit-articles'] );
 
-    $rendered = view()->file( __DIR__ . '/../views/permission-directive.blade.php')->render();
+    $rendered = view()->file( __DIR__ . '/../views/permission-directive.blade.php' )->render();
 
-    expect( $rendered)->not->toContain( 'User can edit articles');
+    expect( $rendered )->not->toContain( 'User can edit articles' );
 });

--- a/tests/Feature/Concerns/HasPermissionsTest.php
+++ b/tests/Feature/Concerns/HasPermissionsTest.php
@@ -62,9 +62,9 @@ it( 'flushes the permission cache on demand', function (): void {
 
     expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeTrue();
 
-    $role->permissions()->detach( $permission);
-    $user->load( 'roles.permissions');
+    $role->permissions()->detach( $permission );
+    $user->load( 'roles.permissions' );
     $user->flushPermissionCache();
 
-    expect( $user->hasPermissionTo( 'edit-articles'))->toBeFalse();
+    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeFalse();
 });

--- a/tests/Feature/Concerns/HasPermissionsTest.php
+++ b/tests/Feature/Concerns/HasPermissionsTest.php
@@ -1,70 +1,70 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 use Tests\Models\TestUser;
 
-it('returns true for permissions held through a directly-assigned role', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'editor']);
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $role->permissions()->attach($permission);
-    $user->roles()->attach($role);
+it( 'returns true for permissions held through a directly-assigned role', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
 
-    expect($user->hasPermissionTo('edit-articles'))->toBeTrue();
-    expect($user->hasPermissionTo('delete-articles'))->toBeFalse();
-});
+    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeTrue();
+    expect( $user->hasPermissionTo( 'delete-articles' ) )->toBeFalse();
+} );
 
-it('aliases hasPermission to hasPermissionTo', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'editor']);
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $role->permissions()->attach($permission);
-    $user->roles()->attach($role);
+it( 'aliases hasPermission to hasPermissionTo', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
 
-    expect($user->hasPermission('edit-articles'))->toBeTrue();
-});
+    expect( $user->hasPermission( 'edit-articles' ) )->toBeTrue();
+} );
 
-it('walks the role hierarchy when resolving permissions', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $admin = Role::create(['name' => 'admin']);
-    $editor = Role::create(['name' => 'editor', 'parent_id' => $admin->id]);
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $admin->permissions()->attach($permission);
-    $user->roles()->attach($editor);
+it( 'walks the role hierarchy when resolving permissions', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $admin      = Role::create( ['name' => 'admin'] );
+    $editor     = Role::create( ['name' => 'editor', 'parent_id' => $admin->id] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $admin->permissions()->attach( $permission );
+    $user->roles()->attach( $editor );
 
-    expect($user->hasPermissionTo('edit-articles'))->toBeTrue();
-});
+    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeTrue();
+} );
 
-it('does not loop when role hierarchy contains a cycle', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $a = Role::create(['name' => 'a']);
-    $b = Role::create(['name' => 'b', 'parent_id' => $a->id]);
-    $a->update(['parent_id' => $b->id]);
+it( 'does not loop when role hierarchy contains a cycle', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $a    = Role::create( ['name' => 'a'] );
+    $b    = Role::create( ['name' => 'b', 'parent_id' => $a->id] );
+    $a->update( ['parent_id' => $b->id] );
 
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $a->permissions()->attach($permission);
-    $user->roles()->attach($b);
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $a->permissions()->attach( $permission );
+    $user->roles()->attach( $b );
 
-    expect($user->hasPermissionTo('edit-articles'))->toBeTrue();
-    expect($user->hasPermissionTo('unknown'))->toBeFalse();
-});
+    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeTrue();
+    expect( $user->hasPermissionTo( 'unknown' ) )->toBeFalse();
+} );
 
-it('flushes the permission cache on demand', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'editor']);
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $role->permissions()->attach($permission);
-    $user->roles()->attach($role);
-    $user->load('roles.permissions');
+it( 'flushes the permission cache on demand', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
+    $user->load( 'roles.permissions' );
 
-    expect($user->hasPermissionTo('edit-articles'))->toBeTrue();
+    expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeTrue();
 
-    $role->permissions()->detach($permission);
-    $user->load('roles.permissions');
+    $role->permissions()->detach( $permission);
+    $user->load( 'roles.permissions');
     $user->flushPermissionCache();
 
-    expect($user->hasPermissionTo('edit-articles'))->toBeFalse();
+    expect( $user->hasPermissionTo( 'edit-articles'))->toBeFalse();
 });

--- a/tests/Feature/Concerns/HasPermissionsTest.php
+++ b/tests/Feature/Concerns/HasPermissionsTest.php
@@ -67,4 +67,4 @@ it( 'flushes the permission cache on demand', function (): void {
     $user->flushPermissionCache();
 
     expect( $user->hasPermissionTo( 'edit-articles' ) )->toBeFalse();
-});
+} );

--- a/tests/Feature/Concerns/HasRolesTest.php
+++ b/tests/Feature/Concerns/HasRolesTest.php
@@ -1,103 +1,103 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Role;
 use Illuminate\Support\Facades\Event;
 use Tests\Models\TestUser;
 
-it('has a roles relationship', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'admin']);
+it( 'has a roles relationship', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role = Role::create( ['name' => 'admin'] );
 
-    $user->roles()->attach($role);
+    $user->roles()->attach( $role );
 
-    expect($user->roles)->toHaveCount(1);
-    expect($user->roles->first()->name)->toBe('admin');
-});
+    expect( $user->roles )->toHaveCount( 1 );
+    expect( $user->roles->first()->name )->toBe( 'admin' );
+} );
 
-it('returns true for hasRole when the user has the named role', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $user->roles()->attach(Role::create(['name' => 'admin']));
+it( 'returns true for hasRole when the user has the named role', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $user->roles()->attach( Role::create( ['name' => 'admin'] ) );
 
-    expect($user->hasRole('admin'))->toBeTrue();
-    expect($user->hasRole('moderator'))->toBeFalse();
-});
+    expect( $user->hasRole( 'admin' ) )->toBeTrue();
+    expect( $user->hasRole( 'moderator' ) )->toBeFalse();
+} );
 
-it('accepts a Role instance for hasRole', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'admin']);
-    $user->roles()->attach($role);
+it( 'accepts a Role instance for hasRole', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role = Role::create( ['name' => 'admin'] );
+    $user->roles()->attach( $role );
 
-    expect($user->hasRole($role))->toBeTrue();
-    expect($user->hasRole(Role::create(['name' => 'other'])))->toBeFalse();
-});
+    expect( $user->hasRole( $role ) )->toBeTrue();
+    expect( $user->hasRole( Role::create( ['name' => 'other'] ) ) )->toBeFalse();
+} );
 
-it('accepts a Collection for hasRole and returns true when any match', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $admin = Role::create(['name' => 'admin']);
-    $mod = Role::create(['name' => 'moderator']);
-    $user->roles()->attach($admin);
+it( 'accepts a Collection for hasRole and returns true when any match', function (): void {
+    $user  = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $admin = Role::create( ['name' => 'admin'] );
+    $mod   = Role::create( ['name' => 'moderator'] );
+    $user->roles()->attach( $admin );
 
-    expect($user->hasRole(collect([$admin, $mod])))->toBeTrue();
-    expect($user->hasRole(collect([$mod])))->toBeFalse();
-});
+    expect( $user->hasRole( collect( [$admin, $mod] ) ) )->toBeTrue();
+    expect( $user->hasRole( collect( [$mod] ) ) )->toBeFalse();
+} );
 
-it('assigns a role by name', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    Role::create(['name' => 'admin']);
+it( 'assigns a role by name', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    Role::create( ['name' => 'admin'] );
 
-    $user->assignRole('admin');
+    $user->assignRole( 'admin' );
 
-    expect($user->fresh()->hasRole('admin'))->toBeTrue();
-});
+    expect( $user->fresh()->hasRole( 'admin' ) )->toBeTrue();
+} );
 
-it('assigns a role by Role instance', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'admin']);
+it( 'assigns a role by Role instance', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role = Role::create( ['name' => 'admin'] );
 
-    $user->assignRole($role);
+    $user->assignRole( $role );
 
-    expect($user->fresh()->hasRole('admin'))->toBeTrue();
-});
+    expect( $user->fresh()->hasRole( 'admin' ) )->toBeTrue();
+} );
 
-it('is idempotent when assigning the same role twice', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    Role::create(['name' => 'admin']);
+it( 'is idempotent when assigning the same role twice', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    Role::create( ['name' => 'admin'] );
 
-    $user->assignRole('admin');
-    $user->assignRole('admin');
+    $user->assignRole( 'admin' );
+    $user->assignRole( 'admin' );
 
-    expect($user->fresh()->roles)->toHaveCount(1);
-});
+    expect( $user->fresh()->roles )->toHaveCount( 1 );
+} );
 
-it('silently no-ops when assigning an unknown role name', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+it( 'silently no-ops when assigning an unknown role name', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
 
-    $user->assignRole('ghost');
+    $user->assignRole( 'ghost' );
 
-    expect($user->fresh()->roles)->toHaveCount(0);
-});
+    expect( $user->fresh()->roles )->toHaveCount( 0 );
+} );
 
-it('removes a role', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    Role::create(['name' => 'admin']);
-    $user->assignRole('admin');
+it( 'removes a role', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    Role::create( ['name' => 'admin'] );
+    $user->assignRole( 'admin' );
 
-    $user->removeRole('admin');
+    $user->removeRole( 'admin' );
 
-    expect($user->fresh()->hasRole('admin'))->toBeFalse();
-});
+    expect( $user->fresh()->hasRole( 'admin' ) )->toBeFalse();
+} );
 
-it('dispatches events when roles are assigned and removed', function (): void {
+it( 'dispatches events when roles are assigned and removed', function (): void {
     Event::fake();
 
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    Role::create(['name' => 'admin']);
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com']);
+    Role::create( ['name' => 'admin']);
 
-    $user->assignRole('admin');
-    $user->removeRole('admin');
+    $user->assignRole( 'admin');
+    $user->removeRole( 'admin');
 
-    Event::assertDispatched('rbac.user.role_assigned');
-    Event::assertDispatched('rbac.user.role_removed');
+    Event::assertDispatched( 'rbac.user.role_assigned');
+    Event::assertDispatched( 'rbac.user.role_removed');
 });

--- a/tests/Feature/Concerns/HasRolesTest.php
+++ b/tests/Feature/Concerns/HasRolesTest.php
@@ -100,4 +100,4 @@ it( 'dispatches events when roles are assigned and removed', function (): void {
 
     Event::assertDispatched( 'rbac.user.role_assigned' );
     Event::assertDispatched( 'rbac.user.role_removed' );
-});
+} );

--- a/tests/Feature/Concerns/HasRolesTest.php
+++ b/tests/Feature/Concerns/HasRolesTest.php
@@ -92,12 +92,12 @@ it( 'removes a role', function (): void {
 it( 'dispatches events when roles are assigned and removed', function (): void {
     Event::fake();
 
-    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com']);
-    Role::create( ['name' => 'admin']);
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    Role::create( ['name' => 'admin'] );
 
-    $user->assignRole( 'admin');
-    $user->removeRole( 'admin');
+    $user->assignRole( 'admin' );
+    $user->removeRole( 'admin' );
 
-    Event::assertDispatched( 'rbac.user.role_assigned');
-    Event::assertDispatched( 'rbac.user.role_removed');
+    Event::assertDispatched( 'rbac.user.role_assigned' );
+    Event::assertDispatched( 'rbac.user.role_removed' );
 });

--- a/tests/Feature/ConfigurableModelBindingTest.php
+++ b/tests/Feature/ConfigurableModelBindingTest.php
@@ -52,4 +52,4 @@ it( 'falls back to base models when no override is configured', function (): voi
 
     expect( $role )->toBeInstanceOf( Role::class );
     expect( $permission )->toBeInstanceOf( Permission::class );
-});
+} );

--- a/tests/Feature/ConfigurableModelBindingTest.php
+++ b/tests/Feature/ConfigurableModelBindingTest.php
@@ -50,6 +50,6 @@ it( 'falls back to base models when no override is configured', function (): voi
     $role       = Role::create( ['name' => 'admin'] );
     $permission = Permission::create( ['name' => 'edit-articles'] );
 
-    expect( $role)->toBeInstanceOf( Role::class);
-    expect( $permission)->toBeInstanceOf( Permission::class);
+    expect( $role )->toBeInstanceOf( Role::class );
+    expect( $permission )->toBeInstanceOf( Permission::class );
 });

--- a/tests/Feature/ConfigurableModelBindingTest.php
+++ b/tests/Feature/ConfigurableModelBindingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
@@ -9,47 +9,47 @@ use Tests\Models\CustomPermission;
 use Tests\Models\CustomRole;
 use Tests\Models\TestUser;
 
-it('role:create command honors a configured custom role model', function (): void {
-    Config::set('artisanpack.rbac.models.role', CustomRole::class);
+it( 'role:create command honors a configured custom role model', function (): void {
+    Config::set( 'artisanpack.rbac.models.role', CustomRole::class );
 
-    $this->artisan('role:create', ['name' => 'admin'])->assertSuccessful();
+    $this->artisan( 'role:create', ['name' => 'admin'] )->assertSuccessful();
 
-    $role = CustomRole::where('name', 'admin')->first();
-    expect($role)->toBeInstanceOf(CustomRole::class);
-    expect($role->customLabel())->toBe('custom:admin');
-});
+    $role = CustomRole::where( 'name', 'admin' )->first();
+    expect( $role )->toBeInstanceOf( CustomRole::class );
+    expect( $role->customLabel() )->toBe( 'custom:admin' );
+} );
 
-it('permission:create command honors a configured custom permission model', function (): void {
-    Config::set('artisanpack.rbac.models.permission', CustomPermission::class);
+it( 'permission:create command honors a configured custom permission model', function (): void {
+    Config::set( 'artisanpack.rbac.models.permission', CustomPermission::class );
 
-    $this->artisan('permission:create', ['name' => 'edit-articles'])->assertSuccessful();
+    $this->artisan( 'permission:create', ['name' => 'edit-articles'] )->assertSuccessful();
 
-    $permission = CustomPermission::where('name', 'edit-articles')->first();
-    expect($permission)->toBeInstanceOf(CustomPermission::class);
-});
+    $permission = CustomPermission::where( 'name', 'edit-articles' )->first();
+    expect( $permission )->toBeInstanceOf( CustomPermission::class );
+} );
 
-it('HasRoles trait resolves role lookups against the configured model', function (): void {
-    Config::set('artisanpack.rbac.models.role', CustomRole::class);
+it( 'HasRoles trait resolves role lookups against the configured model', function (): void {
+    Config::set( 'artisanpack.rbac.models.role', CustomRole::class );
 
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    CustomRole::create(['name' => 'admin']);
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    CustomRole::create( ['name' => 'admin'] );
 
-    $user->assignRole('admin');
+    $user->assignRole( 'admin' );
 
     $resolved = $user->fresh();
-    $resolved->load('roles');
+    $resolved->load( 'roles' );
 
-    expect($resolved->hasRole('admin'))->toBeTrue();
-    expect($resolved->roles->first())->toBeInstanceOf(CustomRole::class);
-});
+    expect( $resolved->hasRole( 'admin' ) )->toBeTrue();
+    expect( $resolved->roles->first() )->toBeInstanceOf( CustomRole::class );
+} );
 
-it('falls back to base models when no override is configured', function (): void {
-    expect(Config::get('artisanpack.rbac.models.role'))->toBe(Role::class);
-    expect(Config::get('artisanpack.rbac.models.permission'))->toBe(Permission::class);
+it( 'falls back to base models when no override is configured', function (): void {
+    expect( Config::get( 'artisanpack.rbac.models.role' ) )->toBe( Role::class );
+    expect( Config::get( 'artisanpack.rbac.models.permission' ) )->toBe( Permission::class );
 
-    $role = Role::create(['name' => 'admin']);
-    $permission = Permission::create(['name' => 'edit-articles']);
+    $role       = Role::create( ['name' => 'admin'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
 
-    expect($role)->toBeInstanceOf(Role::class);
-    expect($permission)->toBeInstanceOf(Permission::class);
+    expect( $role)->toBeInstanceOf( Role::class);
+    expect( $permission)->toBeInstanceOf( Permission::class);
 });

--- a/tests/Feature/Console/AssignRoleTest.php
+++ b/tests/Feature/Console/AssignRoleTest.php
@@ -1,56 +1,56 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Role;
 use Tests\Models\TestUser;
 
-it('assigns a role to a user by id', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    Role::create(['name' => 'admin']);
+it( 'assigns a role to a user by id', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    Role::create( ['name' => 'admin'] );
 
-    $this->artisan('user:assign-role', ['user' => (string) $user->id, 'role' => 'admin'])
+    $this->artisan( 'user:assign-role', ['user' => (string) $user->id, 'role' => 'admin'] )
         ->assertSuccessful();
 
-    expect($user->fresh()->hasRole('admin'))->toBeTrue();
-});
+    expect( $user->fresh()->hasRole( 'admin' ) )->toBeTrue();
+} );
 
-it('assigns a role to a user by email', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    Role::create(['name' => 'admin']);
+it( 'assigns a role to a user by email', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    Role::create( ['name' => 'admin'] );
 
-    $this->artisan('user:assign-role', ['user' => 'test@example.com', 'role' => 'admin'])
+    $this->artisan( 'user:assign-role', ['user' => 'test@example.com', 'role' => 'admin'] )
         ->assertSuccessful();
 
-    expect($user->fresh()->hasRole('admin'))->toBeTrue();
-});
+    expect( $user->fresh()->hasRole( 'admin' ) )->toBeTrue();
+} );
 
-it('is idempotent when assigning the same role twice', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    Role::create(['name' => 'admin']);
+it( 'is idempotent when assigning the same role twice', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    Role::create( ['name' => 'admin'] );
 
-    $this->artisan('user:assign-role', ['user' => (string) $user->id, 'role' => 'admin'])
+    $this->artisan( 'user:assign-role', ['user' => (string) $user->id, 'role' => 'admin'] )
         ->assertSuccessful();
-    $this->artisan('user:assign-role', ['user' => (string) $user->id, 'role' => 'admin'])
+    $this->artisan( 'user:assign-role', ['user' => (string) $user->id, 'role' => 'admin'] )
         ->assertSuccessful();
 
     $fresh = $user->fresh();
-    $fresh->load('roles');
-    expect($fresh->roles)->toHaveCount(1);
-});
+    $fresh->load( 'roles' );
+    expect( $fresh->roles )->toHaveCount( 1 );
+} );
 
-it('fails when the user does not exist', function (): void {
-    Role::create(['name' => 'admin']);
+it( 'fails when the user does not exist', function (): void {
+    Role::create( ['name' => 'admin'] );
 
-    $this->artisan('user:assign-role', ['user' => '999', 'role' => 'admin'])
+    $this->artisan( 'user:assign-role', ['user' => '999', 'role' => 'admin'] )
         ->assertFailed()
-        ->expectsOutputToContain('User not found.');
-});
+        ->expectsOutputToContain( 'User not found.' );
+} );
 
-it('fails when the role does not exist', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+it( 'fails when the role does not exist', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
 
-    $this->artisan('user:assign-role', ['user' => (string) $user->id, 'role' => 'ghost'])
+    $this->artisan( 'user:assign-role', ['user' => (string) $user->id, 'role' => 'ghost'])
         ->assertFailed()
-        ->expectsOutputToContain('Role not found.');
+        ->expectsOutputToContain( 'Role not found.');
 });

--- a/tests/Feature/Console/AssignRoleTest.php
+++ b/tests/Feature/Console/AssignRoleTest.php
@@ -50,7 +50,7 @@ it( 'fails when the user does not exist', function (): void {
 it( 'fails when the role does not exist', function (): void {
     $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
 
-    $this->artisan( 'user:assign-role', ['user' => (string) $user->id, 'role' => 'ghost'])
+    $this->artisan( 'user:assign-role', ['user' => (string) $user->id, 'role' => 'ghost'] )
         ->assertFailed()
-        ->expectsOutputToContain( 'Role not found.');
-});
+        ->expectsOutputToContain( 'Role not found.' );
+} );

--- a/tests/Feature/Console/CreatePermissionTest.php
+++ b/tests/Feature/Console/CreatePermissionTest.php
@@ -1,32 +1,32 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
-it('creates a permission via the permission:create command', function (): void {
-    $this->artisan('permission:create', ['name' => 'edit-articles'])
+it( 'creates a permission via the permission:create command', function (): void {
+    $this->artisan( 'permission:create', ['name' => 'edit-articles'] )
         ->assertSuccessful()
-        ->expectsOutputToContain('Permission `edit-articles` created successfully.');
+        ->expectsOutputToContain( 'Permission `edit-articles` created successfully.' );
 
-    $this->assertDatabaseHas('permissions', ['name' => 'edit-articles']);
-});
+    $this->assertDatabaseHas( 'permissions', ['name' => 'edit-articles'] );
+} );
 
-it('stores the description option on the permission', function (): void {
-    $this->artisan('permission:create', ['name' => 'publish', '--description' => 'Publish articles'])
+it( 'stores the description option on the permission', function (): void {
+    $this->artisan( 'permission:create', ['name' => 'publish', '--description' => 'Publish articles'] )
         ->assertSuccessful();
 
-    $this->assertDatabaseHas('permissions', ['name' => 'publish', 'description' => 'Publish articles']);
-});
+    $this->assertDatabaseHas( 'permissions', ['name' => 'publish', 'description' => 'Publish articles'] );
+} );
 
-it('auto-derives the slug from the name when --slug is not supplied', function (): void {
-    $this->artisan('permission:create', ['name' => 'Edit Articles'])
+it( 'auto-derives the slug from the name when --slug is not supplied', function (): void {
+    $this->artisan( 'permission:create', ['name' => 'Edit Articles'] )
         ->assertSuccessful();
 
-    $this->assertDatabaseHas('permissions', ['name' => 'Edit Articles', 'slug' => 'edit-articles']);
-});
+    $this->assertDatabaseHas( 'permissions', ['name' => 'Edit Articles', 'slug' => 'edit-articles'] );
+} );
 
-it('accepts a custom --slug option', function (): void {
-    $this->artisan('permission:create', ['name' => 'publish', '--slug' => 'pages.publish'])
+it( 'accepts a custom --slug option', function (): void {
+    $this->artisan( 'permission:create', ['name' => 'publish', '--slug' => 'pages.publish'] )
         ->assertSuccessful();
 
-    $this->assertDatabaseHas('permissions', ['name' => 'publish', 'slug' => 'pages.publish']);
+    $this->assertDatabaseHas( 'permissions', ['name' => 'publish', 'slug' => 'pages.publish']);
 });

--- a/tests/Feature/Console/CreatePermissionTest.php
+++ b/tests/Feature/Console/CreatePermissionTest.php
@@ -28,5 +28,5 @@ it( 'accepts a custom --slug option', function (): void {
     $this->artisan( 'permission:create', ['name' => 'publish', '--slug' => 'pages.publish'] )
         ->assertSuccessful();
 
-    $this->assertDatabaseHas( 'permissions', ['name' => 'publish', 'slug' => 'pages.publish']);
-});
+    $this->assertDatabaseHas( 'permissions', ['name' => 'publish', 'slug' => 'pages.publish'] );
+} );

--- a/tests/Feature/Console/CreateRoleTest.php
+++ b/tests/Feature/Console/CreateRoleTest.php
@@ -28,5 +28,5 @@ it( 'accepts a custom --slug option', function (): void {
     $this->artisan( 'role:create', ['name' => 'Site Owner', '--slug' => 'owner'] )
         ->assertSuccessful();
 
-    $this->assertDatabaseHas( 'roles', ['name' => 'Site Owner', 'slug' => 'owner']);
-});
+    $this->assertDatabaseHas( 'roles', ['name' => 'Site Owner', 'slug' => 'owner'] );
+} );

--- a/tests/Feature/Console/CreateRoleTest.php
+++ b/tests/Feature/Console/CreateRoleTest.php
@@ -1,32 +1,32 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
-it('creates a role via the role:create command', function (): void {
-    $this->artisan('role:create', ['name' => 'admin'])
+it( 'creates a role via the role:create command', function (): void {
+    $this->artisan( 'role:create', ['name' => 'admin'] )
         ->assertSuccessful()
-        ->expectsOutputToContain('Role `admin` created successfully.');
+        ->expectsOutputToContain( 'Role `admin` created successfully.' );
 
-    $this->assertDatabaseHas('roles', ['name' => 'admin']);
-});
+    $this->assertDatabaseHas( 'roles', ['name' => 'admin'] );
+} );
 
-it('stores the description option on the role', function (): void {
-    $this->artisan('role:create', ['name' => 'editor', '--description' => 'Editor role'])
+it( 'stores the description option on the role', function (): void {
+    $this->artisan( 'role:create', ['name' => 'editor', '--description' => 'Editor role'] )
         ->assertSuccessful();
 
-    $this->assertDatabaseHas('roles', ['name' => 'editor', 'description' => 'Editor role']);
-});
+    $this->assertDatabaseHas( 'roles', ['name' => 'editor', 'description' => 'Editor role'] );
+} );
 
-it('auto-derives the slug from the name when --slug is not supplied', function (): void {
-    $this->artisan('role:create', ['name' => 'Site Owner'])
+it( 'auto-derives the slug from the name when --slug is not supplied', function (): void {
+    $this->artisan( 'role:create', ['name' => 'Site Owner'] )
         ->assertSuccessful();
 
-    $this->assertDatabaseHas('roles', ['name' => 'Site Owner', 'slug' => 'site-owner']);
-});
+    $this->assertDatabaseHas( 'roles', ['name' => 'Site Owner', 'slug' => 'site-owner'] );
+} );
 
-it('accepts a custom --slug option', function (): void {
-    $this->artisan('role:create', ['name' => 'Site Owner', '--slug' => 'owner'])
+it( 'accepts a custom --slug option', function (): void {
+    $this->artisan( 'role:create', ['name' => 'Site Owner', '--slug' => 'owner'] )
         ->assertSuccessful();
 
-    $this->assertDatabaseHas('roles', ['name' => 'Site Owner', 'slug' => 'owner']);
+    $this->assertDatabaseHas( 'roles', ['name' => 'Site Owner', 'slug' => 'owner']);
 });

--- a/tests/Feature/Console/RevokeRoleTest.php
+++ b/tests/Feature/Console/RevokeRoleTest.php
@@ -1,31 +1,31 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Role;
 use Tests\Models\TestUser;
 
-it('revokes a role from a user', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'admin']);
-    $user->roles()->attach($role);
+it( 'revokes a role from a user', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role = Role::create( ['name' => 'admin'] );
+    $user->roles()->attach( $role );
 
-    $this->artisan('user:revoke-role', ['user' => (string) $user->id, 'role' => 'admin'])
+    $this->artisan( 'user:revoke-role', ['user' => (string) $user->id, 'role' => 'admin'] )
         ->assertSuccessful();
 
-    expect($user->fresh()->hasRole('admin'))->toBeFalse();
-});
+    expect( $user->fresh()->hasRole( 'admin' ) )->toBeFalse();
+} );
 
-it('fails when the user does not exist', function (): void {
-    Role::create(['name' => 'admin']);
+it( 'fails when the user does not exist', function (): void {
+    Role::create( ['name' => 'admin'] );
 
-    $this->artisan('user:revoke-role', ['user' => '999', 'role' => 'admin'])
+    $this->artisan( 'user:revoke-role', ['user' => '999', 'role' => 'admin'] )
         ->assertFailed();
-});
+} );
 
-it('fails when the role does not exist', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+it( 'fails when the role does not exist', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
 
-    $this->artisan('user:revoke-role', ['user' => (string) $user->id, 'role' => 'ghost'])
+    $this->artisan( 'user:revoke-role', ['user' => (string) $user->id, 'role' => 'ghost'])
         ->assertFailed();
 });

--- a/tests/Feature/Console/RevokeRoleTest.php
+++ b/tests/Feature/Console/RevokeRoleTest.php
@@ -26,6 +26,6 @@ it( 'fails when the user does not exist', function (): void {
 it( 'fails when the role does not exist', function (): void {
     $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
 
-    $this->artisan( 'user:revoke-role', ['user' => (string) $user->id, 'role' => 'ghost'])
+    $this->artisan( 'user:revoke-role', ['user' => (string) $user->id, 'role' => 'ghost'] )
         ->assertFailed();
-});
+} );

--- a/tests/Feature/GateIntegrationTest.php
+++ b/tests/Feature/GateIntegrationTest.php
@@ -54,8 +54,8 @@ it( 'invalidates the permission-name cache when permissions change', function ()
 
     $permission = Permission::create( ['name' => 'publish'] );
     $role->permissions()->attach( $permission );
-    $user->load( 'roles.permissions');
+    $user->load( 'roles.permissions' );
     $user->flushPermissionCache();
 
-    expect( $user->can( 'publish'))->toBeTrue();
+    expect( $user->can( 'publish' ) )->toBeTrue();
 });

--- a/tests/Feature/GateIntegrationTest.php
+++ b/tests/Feature/GateIntegrationTest.php
@@ -1,61 +1,61 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 use Illuminate\Support\Facades\Gate;
 use Tests\Models\TestUser;
 
-it('resolves $user->can() through registered RBAC permissions', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'editor']);
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $role->permissions()->attach($permission);
-    $user->roles()->attach($role);
+it( 'resolves $user->can() through registered RBAC permissions', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
 
-    expect($user->can('edit-articles'))->toBeTrue();
-    expect($user->can('delete-articles'))->toBeFalse();
-});
+    expect( $user->can( 'edit-articles' ) )->toBeTrue();
+    expect( $user->can( 'delete-articles' ) )->toBeFalse();
+} );
 
-it('resolves Gate::allows() through registered RBAC permissions', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'editor']);
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $role->permissions()->attach($permission);
-    $user->roles()->attach($role);
+it( 'resolves Gate::allows() through registered RBAC permissions', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
 
-    $this->actingAs($user);
+    $this->actingAs( $user );
 
-    expect(Gate::allows('edit-articles'))->toBeTrue();
-    expect(Gate::denies('delete-articles'))->toBeTrue();
-});
+    expect( Gate::allows( 'edit-articles' ) )->toBeTrue();
+    expect( Gate::denies( 'delete-articles' ) )->toBeTrue();
+} );
 
-it('falls back to standard Gate behavior for non-RBAC abilities', function (): void {
-    Gate::define('view-dashboard', fn ($user) => true);
+it( 'falls back to standard Gate behavior for non-RBAC abilities', function (): void {
+    Gate::define( 'view-dashboard', fn ( $user ) => true );
 
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
 
-    expect($user->can('view-dashboard'))->toBeTrue();
-});
+    expect( $user->can( 'view-dashboard' ) )->toBeTrue();
+} );
 
-it('denies non-RBAC abilities with no defined Gate', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+it( 'denies non-RBAC abilities with no defined Gate', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
 
-    expect($user->can('undefined-ability'))->toBeFalse();
-});
+    expect( $user->can( 'undefined-ability' ) )->toBeFalse();
+} );
 
-it('invalidates the permission-name cache when permissions change', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'editor']);
-    $user->roles()->attach($role);
+it( 'invalidates the permission-name cache when permissions change', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role = Role::create( ['name' => 'editor'] );
+    $user->roles()->attach( $role );
 
-    expect($user->can('publish'))->toBeFalse();
+    expect( $user->can( 'publish' ) )->toBeFalse();
 
-    $permission = Permission::create(['name' => 'publish']);
-    $role->permissions()->attach($permission);
-    $user->load('roles.permissions');
+    $permission = Permission::create( ['name' => 'publish'] );
+    $role->permissions()->attach( $permission );
+    $user->load( 'roles.permissions');
     $user->flushPermissionCache();
 
-    expect($user->can('publish'))->toBeTrue();
+    expect( $user->can( 'publish'))->toBeTrue();
 });

--- a/tests/Feature/GateIntegrationTest.php
+++ b/tests/Feature/GateIntegrationTest.php
@@ -58,4 +58,4 @@ it( 'invalidates the permission-name cache when permissions change', function ()
     $user->flushPermissionCache();
 
     expect( $user->can( 'publish' ) )->toBeTrue();
-});
+} );

--- a/tests/Feature/Http/CheckPermissionMiddlewareTest.php
+++ b/tests/Feature/Http/CheckPermissionMiddlewareTest.php
@@ -49,9 +49,9 @@ it( 'allows access when the user has any of multiple permissions', function (): 
 } );
 
 it( 'denies access when the user has none of the listed permissions', function (): void {
-    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com']);
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
 
-    $this->actingAs( $user)
-        ->get( '/multi-permission')
-        ->assertStatus( 403);
+    $this->actingAs( $user )
+        ->get( '/multi-permission' )
+        ->assertStatus( 403 );
 });

--- a/tests/Feature/Http/CheckPermissionMiddlewareTest.php
+++ b/tests/Feature/Http/CheckPermissionMiddlewareTest.php
@@ -54,4 +54,4 @@ it( 'denies access when the user has none of the listed permissions', function (
     $this->actingAs( $user )
         ->get( '/multi-permission' )
         ->assertStatus( 403 );
-});
+} );

--- a/tests/Feature/Http/CheckPermissionMiddlewareTest.php
+++ b/tests/Feature/Http/CheckPermissionMiddlewareTest.php
@@ -1,57 +1,57 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 use Illuminate\Support\Facades\Route;
 use Tests\Models\TestUser;
 
-beforeEach(function (): void {
-    Route::get('/protected-route', fn () => 'Success')->middleware('permission:edit-articles');
-    Route::get('/multi-permission', fn () => 'Success')->middleware('permission:edit-articles,delete-articles');
-});
+beforeEach( function (): void {
+    Route::get( '/protected-route', fn () => 'Success' )->middleware( 'permission:edit-articles' );
+    Route::get( '/multi-permission', fn () => 'Success' )->middleware( 'permission:edit-articles,delete-articles' );
+} );
 
-it('returns 401 for unauthenticated users', function (): void {
-    $this->get('/protected-route')->assertStatus(401);
-});
+it( 'returns 401 for unauthenticated users', function (): void {
+    $this->get( '/protected-route' )->assertStatus( 401 );
+} );
 
-it('returns 403 when an authenticated user lacks the permission', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+it( 'returns 403 when an authenticated user lacks the permission', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
 
-    $this->actingAs($user)
-        ->get('/protected-route')
-        ->assertStatus(403);
-});
+    $this->actingAs( $user )
+        ->get( '/protected-route' )
+        ->assertStatus( 403 );
+} );
 
-it('returns 200 when the user has the required permission', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'editor']);
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $role->permissions()->attach($permission);
-    $user->roles()->attach($role);
+it( 'returns 200 when the user has the required permission', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
 
-    $this->actingAs($user)
-        ->get('/protected-route')
-        ->assertStatus(200);
-});
+    $this->actingAs( $user )
+        ->get( '/protected-route' )
+        ->assertStatus( 200 );
+} );
 
-it('allows access when the user has any of multiple permissions', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
-    $role = Role::create(['name' => 'reviewer']);
-    $permission = Permission::create(['name' => 'delete-articles']);
-    $role->permissions()->attach($permission);
-    $user->roles()->attach($role);
+it( 'allows access when the user has any of multiple permissions', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com'] );
+    $role       = Role::create( ['name' => 'reviewer'] );
+    $permission = Permission::create( ['name' => 'delete-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
 
-    $this->actingAs($user)
-        ->get('/multi-permission')
-        ->assertStatus(200);
-});
+    $this->actingAs( $user )
+        ->get( '/multi-permission' )
+        ->assertStatus( 200 );
+} );
 
-it('denies access when the user has none of the listed permissions', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'test@example.com']);
+it( 'denies access when the user has none of the listed permissions', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'test@example.com']);
 
-    $this->actingAs($user)
-        ->get('/multi-permission')
-        ->assertStatus(403);
+    $this->actingAs( $user)
+        ->get( '/multi-permission')
+        ->assertStatus( 403);
 });

--- a/tests/Feature/Models/PermissionTest.php
+++ b/tests/Feature/Models/PermissionTest.php
@@ -30,5 +30,5 @@ it( 'detaches roles when a permission is deleted', function (): void {
 
     $permission->delete();
 
-    $this->assertDatabaseMissing( 'permission_role', ['permission_id' => $permission->id]);
-});
+    $this->assertDatabaseMissing( 'permission_role', ['permission_id' => $permission->id] );
+} );

--- a/tests/Feature/Models/PermissionTest.php
+++ b/tests/Feature/Models/PermissionTest.php
@@ -1,34 +1,34 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 
-it('creates a permission', function (): void {
-    $permission = Permission::create(['name' => 'edit-articles', 'description' => 'Edit articles']);
+it( 'creates a permission', function (): void {
+    $permission = Permission::create( ['name' => 'edit-articles', 'description' => 'Edit articles'] );
 
-    expect($permission->name)->toBe('edit-articles');
-    $this->assertDatabaseHas('permissions', ['name' => 'edit-articles']);
-});
+    expect( $permission->name )->toBe( 'edit-articles' );
+    $this->assertDatabaseHas( 'permissions', ['name' => 'edit-articles'] );
+} );
 
-it('belongs to many roles', function (): void {
-    $permission = Permission::create(['name' => 'publish']);
-    $admin = Role::create(['name' => 'admin']);
-    $editor = Role::create(['name' => 'editor']);
+it( 'belongs to many roles', function (): void {
+    $permission = Permission::create( ['name' => 'publish'] );
+    $admin      = Role::create( ['name' => 'admin'] );
+    $editor     = Role::create( ['name' => 'editor'] );
 
-    $permission->roles()->attach([$admin->id, $editor->id]);
-    $permission->load('roles');
+    $permission->roles()->attach( [$admin->id, $editor->id] );
+    $permission->load( 'roles' );
 
-    expect($permission->roles)->toHaveCount(2);
-});
+    expect( $permission->roles )->toHaveCount( 2 );
+} );
 
-it('detaches roles when a permission is deleted', function (): void {
-    $permission = Permission::create(['name' => 'publish']);
-    $role = Role::create(['name' => 'admin']);
-    $permission->roles()->attach($role);
+it( 'detaches roles when a permission is deleted', function (): void {
+    $permission = Permission::create( ['name' => 'publish'] );
+    $role       = Role::create( ['name' => 'admin'] );
+    $permission->roles()->attach( $role );
 
     $permission->delete();
 
-    $this->assertDatabaseMissing('permission_role', ['permission_id' => $permission->id]);
+    $this->assertDatabaseMissing( 'permission_role', ['permission_id' => $permission->id]);
 });

--- a/tests/Feature/Models/RoleTest.php
+++ b/tests/Feature/Models/RoleTest.php
@@ -46,9 +46,9 @@ it( 'detaches permissions when a role is deleted', function (): void {
 
 it( 'nulls parent_id on children when a parent role is deleted', function (): void {
     $admin  = Role::create( ['name' => 'admin'] );
-    $editor = Role::create( ['name' => 'editor', 'parent_id' => $admin->id]);
+    $editor = Role::create( ['name' => 'editor', 'parent_id' => $admin->id] );
 
     $admin->delete();
 
-    expect( $editor->fresh()->parent_id)->toBeNull();
-});
+    expect( $editor->fresh()->parent_id )->toBeNull();
+} );

--- a/tests/Feature/Models/RoleTest.php
+++ b/tests/Feature/Models/RoleTest.php
@@ -1,54 +1,54 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 
-it('creates a role', function (): void {
-    $role = Role::create(['name' => 'admin', 'description' => 'Administrator']);
+it( 'creates a role', function (): void {
+    $role = Role::create( ['name' => 'admin', 'description' => 'Administrator'] );
 
-    expect($role->name)->toBe('admin');
-    expect($role->description)->toBe('Administrator');
-    $this->assertDatabaseHas('roles', ['name' => 'admin']);
-});
+    expect( $role->name )->toBe( 'admin' );
+    expect( $role->description )->toBe( 'Administrator' );
+    $this->assertDatabaseHas( 'roles', ['name' => 'admin'] );
+} );
 
-it('attaches permissions to a role', function (): void {
-    $role = Role::create(['name' => 'editor']);
-    $permission = Permission::create(['name' => 'edit-articles']);
+it( 'attaches permissions to a role', function (): void {
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
 
-    $role->permissions()->attach($permission);
-    $role->load('permissions');
+    $role->permissions()->attach( $permission );
+    $role->load( 'permissions' );
 
-    expect($role->permissions)->toHaveCount(1);
-    expect($role->permissions->first()->name)->toBe('edit-articles');
-});
+    expect( $role->permissions )->toHaveCount( 1 );
+    expect( $role->permissions->first()->name )->toBe( 'edit-articles' );
+} );
 
-it('supports parent/child role hierarchy', function (): void {
-    $admin = Role::create(['name' => 'admin']);
-    $editor = Role::create(['name' => 'editor', 'parent_id' => $admin->id]);
-    $editor->load('parent');
-    $admin->load('children');
+it( 'supports parent/child role hierarchy', function (): void {
+    $admin  = Role::create( ['name' => 'admin'] );
+    $editor = Role::create( ['name' => 'editor', 'parent_id' => $admin->id] );
+    $editor->load( 'parent' );
+    $admin->load( 'children' );
 
-    expect($editor->parent->id)->toBe($admin->id);
-    expect($admin->children->first()->id)->toBe($editor->id);
-});
+    expect( $editor->parent->id )->toBe( $admin->id );
+    expect( $admin->children->first()->id )->toBe( $editor->id );
+} );
 
-it('detaches permissions when a role is deleted', function (): void {
-    $role = Role::create(['name' => 'admin']);
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $role->permissions()->attach($permission);
+it( 'detaches permissions when a role is deleted', function (): void {
+    $role       = Role::create( ['name' => 'admin'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
 
     $role->delete();
 
-    $this->assertDatabaseMissing('permission_role', ['role_id' => $role->id]);
-});
+    $this->assertDatabaseMissing( 'permission_role', ['role_id' => $role->id] );
+} );
 
-it('nulls parent_id on children when a parent role is deleted', function (): void {
-    $admin = Role::create(['name' => 'admin']);
-    $editor = Role::create(['name' => 'editor', 'parent_id' => $admin->id]);
+it( 'nulls parent_id on children when a parent role is deleted', function (): void {
+    $admin  = Role::create( ['name' => 'admin'] );
+    $editor = Role::create( ['name' => 'editor', 'parent_id' => $admin->id]);
 
     $admin->delete();
 
-    expect($editor->fresh()->parent_id)->toBeNull();
+    expect( $editor->fresh()->parent_id)->toBeNull();
 });

--- a/tests/Feature/Observers/ObserverEventsTest.php
+++ b/tests/Feature/Observers/ObserverEventsTest.php
@@ -73,4 +73,4 @@ it( 'dispatches rbac.permission.deleted when a permission is deleted', function 
     $permission->delete();
 
     expect( $captured->fired )->toBeTrue();
-});
+} );

--- a/tests/Feature/Observers/ObserverEventsTest.php
+++ b/tests/Feature/Observers/ObserverEventsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
@@ -11,66 +11,66 @@ use Illuminate\Support\Facades\Event;
  * events that drive the observers, so we instead listen for the package
  * events directly and assert they fired.
  */
-function captureEvent(string $name): stdClass
+function captureEvent( string $name ): stdClass
 {
-    $captured = new stdClass;
+    $captured        = new stdClass;
     $captured->fired = false;
 
-    Event::listen($name, function () use ($captured): void {
+    Event::listen( $name, function () use ( $captured ): void {
         $captured->fired = true;
-    });
+    } );
 
     return $captured;
 }
 
-it('dispatches rbac.role.created when a role is created', function (): void {
-    $captured = captureEvent('rbac.role.created');
+it( 'dispatches rbac.role.created when a role is created', function (): void {
+    $captured = captureEvent( 'rbac.role.created' );
 
-    Role::create(['name' => 'admin']);
+    Role::create( ['name' => 'admin'] );
 
-    expect($captured->fired)->toBeTrue();
-});
+    expect( $captured->fired )->toBeTrue();
+} );
 
-it('dispatches rbac.role.updated when a role is updated', function (): void {
-    $role = Role::create(['name' => 'admin']);
-    $captured = captureEvent('rbac.role.updated');
+it( 'dispatches rbac.role.updated when a role is updated', function (): void {
+    $role     = Role::create( ['name' => 'admin'] );
+    $captured = captureEvent( 'rbac.role.updated' );
 
-    $role->update(['description' => 'Administrator']);
+    $role->update( ['description' => 'Administrator'] );
 
-    expect($captured->fired)->toBeTrue();
-});
+    expect( $captured->fired )->toBeTrue();
+} );
 
-it('dispatches rbac.role.deleted when a role is deleted', function (): void {
-    $role = Role::create(['name' => 'admin']);
-    $captured = captureEvent('rbac.role.deleted');
+it( 'dispatches rbac.role.deleted when a role is deleted', function (): void {
+    $role     = Role::create( ['name' => 'admin'] );
+    $captured = captureEvent( 'rbac.role.deleted' );
 
     $role->delete();
 
-    expect($captured->fired)->toBeTrue();
-});
+    expect( $captured->fired )->toBeTrue();
+} );
 
-it('dispatches rbac.permission.created when a permission is created', function (): void {
-    $captured = captureEvent('rbac.permission.created');
+it( 'dispatches rbac.permission.created when a permission is created', function (): void {
+    $captured = captureEvent( 'rbac.permission.created' );
 
-    Permission::create(['name' => 'edit-articles']);
+    Permission::create( ['name' => 'edit-articles'] );
 
-    expect($captured->fired)->toBeTrue();
-});
+    expect( $captured->fired )->toBeTrue();
+} );
 
-it('dispatches rbac.permission.updated when a permission is updated', function (): void {
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $captured = captureEvent('rbac.permission.updated');
+it( 'dispatches rbac.permission.updated when a permission is updated', function (): void {
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $captured   = captureEvent( 'rbac.permission.updated' );
 
-    $permission->update(['description' => 'Edit articles']);
+    $permission->update( ['description' => 'Edit articles'] );
 
-    expect($captured->fired)->toBeTrue();
-});
+    expect( $captured->fired )->toBeTrue();
+} );
 
-it('dispatches rbac.permission.deleted when a permission is deleted', function (): void {
-    $permission = Permission::create(['name' => 'edit-articles']);
-    $captured = captureEvent('rbac.permission.deleted');
+it( 'dispatches rbac.permission.deleted when a permission is deleted', function (): void {
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $captured   = captureEvent( 'rbac.permission.deleted');
 
     $permission->delete();
 
-    expect($captured->fired)->toBeTrue();
+    expect( $captured->fired)->toBeTrue();
 });

--- a/tests/Feature/Observers/ObserverEventsTest.php
+++ b/tests/Feature/Observers/ObserverEventsTest.php
@@ -68,9 +68,9 @@ it( 'dispatches rbac.permission.updated when a permission is updated', function 
 
 it( 'dispatches rbac.permission.deleted when a permission is deleted', function (): void {
     $permission = Permission::create( ['name' => 'edit-articles'] );
-    $captured   = captureEvent( 'rbac.permission.deleted');
+    $captured   = captureEvent( 'rbac.permission.deleted' );
 
     $permission->delete();
 
-    expect( $captured->fired)->toBeTrue();
+    expect( $captured->fired )->toBeTrue();
 });

--- a/tests/Feature/SlugDerivationTest.php
+++ b/tests/Feature/SlugDerivationTest.php
@@ -100,8 +100,8 @@ it( 'resolves hasRole to the name-matched row when another row has the same stri
     $a = Role::create( ['name' => 'shipper', 'slug' => 'shipper-role'] );
     Role::create( ['name' => 'Shipping', 'slug' => 'shipper-2'] );
 
-    $user = TestUser::create( ['name' => 'Test', 'email' => 'collision@example.com']);
-    $user->assignRole( 'shipper');
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'collision@example.com'] );
+    $user->assignRole( 'shipper' );
 
-    expect( $user->roles->pluck( 'id')->all())->toBe( [$a->id]);
+    expect( $user->roles->pluck( 'id' )->all() )->toBe( [$a->id] );
 });

--- a/tests/Feature/SlugDerivationTest.php
+++ b/tests/Feature/SlugDerivationTest.php
@@ -104,4 +104,4 @@ it( 'resolves hasRole to the name-matched row when another row has the same stri
     $user->assignRole( 'shipper' );
 
     expect( $user->roles->pluck( 'id' )->all() )->toBe( [$a->id] );
-});
+} );

--- a/tests/Feature/SlugDerivationTest.php
+++ b/tests/Feature/SlugDerivationTest.php
@@ -1,107 +1,107 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 use Tests\Models\TestUser;
 
-it('derives slug from name when slug is not provided on Role', function (): void {
-    $role = Role::create(['name' => 'Site Owner']);
+it( 'derives slug from name when slug is not provided on Role', function (): void {
+    $role = Role::create( ['name' => 'Site Owner'] );
 
-    expect($role->slug)->toBe('site-owner');
-});
+    expect( $role->slug )->toBe( 'site-owner' );
+} );
 
-it('derives slug from name when slug is not provided on Permission', function (): void {
-    $permission = Permission::create(['name' => 'Manage Users']);
+it( 'derives slug from name when slug is not provided on Permission', function (): void {
+    $permission = Permission::create( ['name' => 'Manage Users'] );
 
-    expect($permission->slug)->toBe('manage-users');
-});
+    expect( $permission->slug )->toBe( 'manage-users' );
+} );
 
-it('preserves a slug supplied at creation time on Role', function (): void {
-    $role = Role::create(['name' => 'Site Owner', 'slug' => 'owner']);
+it( 'preserves a slug supplied at creation time on Role', function (): void {
+    $role = Role::create( ['name' => 'Site Owner', 'slug' => 'owner'] );
 
-    expect($role->slug)->toBe('owner');
-});
+    expect( $role->slug )->toBe( 'owner' );
+} );
 
-it('preserves a slug supplied at creation time on Permission', function (): void {
-    $permission = Permission::create(['name' => 'Manage Users', 'slug' => 'users.manage']);
+it( 'preserves a slug supplied at creation time on Permission', function (): void {
+    $permission = Permission::create( ['name' => 'Manage Users', 'slug' => 'users.manage'] );
 
-    expect($permission->slug)->toBe('users.manage');
-});
+    expect( $permission->slug )->toBe( 'users.manage' );
+} );
 
-it('looks up a Role by slug via findBySlug', function (): void {
-    Role::create(['name' => 'Editor', 'slug' => 'editor']);
+it( 'looks up a Role by slug via findBySlug', function (): void {
+    Role::create( ['name' => 'Editor', 'slug' => 'editor'] );
 
-    $found = Role::findBySlug('editor');
+    $found = Role::findBySlug( 'editor' );
 
-    expect($found)->not->toBeNull()
-        ->and($found->name)->toBe('Editor');
-});
+    expect( $found )->not->toBeNull()
+        ->and( $found->name )->toBe( 'Editor' );
+} );
 
-it('looks up a Permission by slug via findBySlug', function (): void {
-    Permission::create(['name' => 'Publish Pages', 'slug' => 'pages.publish']);
+it( 'looks up a Permission by slug via findBySlug', function (): void {
+    Permission::create( ['name' => 'Publish Pages', 'slug' => 'pages.publish'] );
 
-    $found = Permission::findBySlug('pages.publish');
+    $found = Permission::findBySlug( 'pages.publish' );
 
-    expect($found)->not->toBeNull()
-        ->and($found->name)->toBe('Publish Pages');
-});
+    expect( $found )->not->toBeNull()
+        ->and( $found->name )->toBe( 'Publish Pages' );
+} );
 
-it('matches hasRole by slug as well as name', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'slug-role@example.com']);
-    Role::create(['name' => 'Editor', 'slug' => 'editor']);
+it( 'matches hasRole by slug as well as name', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'slug-role@example.com'] );
+    Role::create( ['name' => 'Editor', 'slug' => 'editor'] );
 
-    $user->assignRole('editor');
+    $user->assignRole( 'editor' );
 
-    expect($user->hasRole('editor'))->toBeTrue()
-        ->and($user->hasRole('Editor'))->toBeTrue();
-});
+    expect( $user->hasRole( 'editor' ) )->toBeTrue()
+        ->and( $user->hasRole( 'Editor' ) )->toBeTrue();
+} );
 
-it('matches hasPermissionTo by slug as well as name', function (): void {
-    $user = TestUser::create(['name' => 'Test', 'email' => 'slug-perm@example.com']);
-    $role = Role::create(['name' => 'Editor', 'slug' => 'editor']);
-    $permission = Permission::create(['name' => 'Publish Pages', 'slug' => 'pages.publish']);
+it( 'matches hasPermissionTo by slug as well as name', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'slug-perm@example.com'] );
+    $role       = Role::create( ['name' => 'Editor', 'slug' => 'editor'] );
+    $permission = Permission::create( ['name' => 'Publish Pages', 'slug' => 'pages.publish'] );
 
-    $role->permissions()->attach($permission);
-    $user->assignRole('editor');
+    $role->permissions()->attach( $permission );
+    $user->assignRole( 'editor' );
 
-    expect($user->hasPermissionTo('pages.publish'))->toBeTrue()
-        ->and($user->hasPermissionTo('Publish Pages'))->toBeTrue();
-});
+    expect( $user->hasPermissionTo( 'pages.publish' ) )->toBeTrue()
+        ->and( $user->hasPermissionTo( 'Publish Pages' ) )->toBeTrue();
+} );
 
-it('rejects a Role save that would collide its name with another row\'s slug', function (): void {
-    Role::create(['name' => 'Editor', 'slug' => 'editor']);
+it( 'rejects a Role save that would collide its name with another row\'s slug', function (): void {
+    Role::create( ['name' => 'Editor', 'slug' => 'editor'] );
 
-    expect(fn () => Role::create(['name' => 'editor', 'slug' => 'second']))
-        ->toThrow(RuntimeException::class);
-});
+    expect( fn () => Role::create( ['name' => 'editor', 'slug' => 'second'] ) )
+        ->toThrow( RuntimeException::class );
+} );
 
-it('rejects a Permission save that would collide its slug with another row\'s name', function (): void {
-    Permission::create(['name' => 'Publish Pages', 'slug' => 'pages.publish']);
+it( 'rejects a Permission save that would collide its slug with another row\'s name', function (): void {
+    Permission::create( ['name' => 'Publish Pages', 'slug' => 'pages.publish'] );
 
-    expect(fn () => Permission::create(['name' => 'Other', 'slug' => 'Publish Pages']))
-        ->toThrow(RuntimeException::class);
-});
+    expect( fn () => Permission::create( ['name' => 'Other', 'slug' => 'Publish Pages'] ) )
+        ->toThrow( RuntimeException::class );
+} );
 
-it('allows a Role save where name and slug are equal on the same row', function (): void {
+it( 'allows a Role save where name and slug are equal on the same row', function (): void {
     // Most common post-auto-derivation case: name === slug on the same
     // row. The collision guard must allow this.
-    $role = Role::create(['name' => 'editor', 'slug' => 'editor']);
+    $role = Role::create( ['name' => 'editor', 'slug' => 'editor'] );
 
-    expect($role->name)->toBe('editor')
-        ->and($role->slug)->toBe('editor');
-});
+    expect( $role->name )->toBe( 'editor' )
+        ->and( $role->slug )->toBe( 'editor' );
+} );
 
-it('resolves hasRole to the name-matched row when another row has the same string as a slug', function (): void {
+it( 'resolves hasRole to the name-matched row when another row has the same string as a slug', function (): void {
     // Cross-row collision regression: Role A has name='shipper', Role B
     // has name='Shipping' but slug='shipper'. assignRole('shipper') must
     // resolve to Role A (name match wins).
-    $a = Role::create(['name' => 'shipper', 'slug' => 'shipper-role']);
-    Role::create(['name' => 'Shipping', 'slug' => 'shipper-2']);
+    $a = Role::create( ['name' => 'shipper', 'slug' => 'shipper-role'] );
+    Role::create( ['name' => 'Shipping', 'slug' => 'shipper-2'] );
 
-    $user = TestUser::create(['name' => 'Test', 'email' => 'collision@example.com']);
-    $user->assignRole('shipper');
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'collision@example.com']);
+    $user->assignRole( 'shipper');
 
-    expect($user->roles->pluck('id')->all())->toBe([$a->id]);
+    expect( $user->roles->pluck( 'id')->all())->toBe( [$a->id]);
 });

--- a/tests/Models/CustomPermission.php
+++ b/tests/Models/CustomPermission.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace Tests\Models;
 
@@ -12,6 +12,6 @@ class CustomPermission extends Permission
 
     public function customLabel(): string
     {
-        return 'custom:'.$this->name;
+        return 'custom:' . $this->name;
     }
 }

--- a/tests/Models/CustomRole.php
+++ b/tests/Models/CustomRole.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace Tests\Models;
 
@@ -12,6 +12,6 @@ class CustomRole extends Role
 
     public function customLabel(): string
     {
-        return 'custom:'.$this->name;
+        return 'custom:' . $this->name;
     }
 }

--- a/tests/Models/TestUser.php
+++ b/tests/Models/TestUser.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace Tests\Models;
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,9 +13,9 @@ use Tests\TestCase;
 |
 */
 
-pest()->extend(TestCase::class)
+pest()->extend( TestCase::class )
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in('Feature');
+    ->in( 'Feature' );
 
 /*
 |--------------------------------------------------------------------------
@@ -28,9 +28,9 @@ pest()->extend(TestCase::class)
 |
 */
 
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
+expect()->extend( 'toBeOne', function () {
+    return $this->toBe( 1 );
+} );
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -80,6 +80,6 @@ abstract class TestCase extends BaseTestCase
             $table->string( 'email' )->unique();
             $table->string( 'password' )->nullable();
             $table->timestamps();
-        });
+        } );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace Tests;
 
@@ -36,9 +36,10 @@ abstract class TestCase extends BaseTestCase
      * Gets package providers.
      *
      * @param  Application  $app  The application instance.
+     *
      * @return array<int, class-string> Array of service provider class names.
      */
-    protected function getPackageProviders($app): array
+    protected function getPackageProviders( $app ): array
     {
         return [
             RbacServiceProvider::class,
@@ -50,19 +51,19 @@ abstract class TestCase extends BaseTestCase
      *
      * @param  Application  $app  The application instance.
      */
-    protected function defineEnvironment($app): void
+    protected function defineEnvironment( $app ): void
     {
-        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        $app['config']->set( 'app.key', 'base64:' . base64_encode( random_bytes( 32 ) ) );
 
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
+        $app['config']->set( 'database.default', 'testbench' );
+        $app['config']->set( 'database.connections.testbench', [
+            'driver'                  => 'sqlite',
+            'database'                => ':memory:',
+            'prefix'                  => '',
             'foreign_key_constraints' => true,
-        ]);
+        ] );
 
-        $app['config']->set('auth.providers.users.model', TestUser::class);
+        $app['config']->set( 'auth.providers.users.model', TestUser::class );
     }
 
     /**
@@ -73,11 +74,11 @@ abstract class TestCase extends BaseTestCase
      */
     protected function defineDatabaseMigrations(): void
     {
-        $this->app['db']->connection()->getSchemaBuilder()->create('users', function (Blueprint $table): void {
-            $table->increments('id');
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->string('password')->nullable();
+        $this->app['db']->connection()->getSchemaBuilder()->create( 'users', function ( Blueprint $table ): void {
+            $table->increments( 'id' );
+            $table->string( 'name' );
+            $table->string( 'email' )->unique();
+            $table->string( 'password' )->nullable();
             $table->timestamps();
         });
     }

--- a/tests/Unit/ModelFillableTest.php
+++ b/tests/Unit/ModelFillableTest.php
@@ -1,14 +1,14 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Rbac\Models\Permission;
 use ArtisanPackUI\Rbac\Models\Role;
 
-it('declares the expected fillable attributes on Role', function (): void {
-    expect((new Role)->getFillable())->toBe(['name', 'slug', 'description', 'parent_id']);
-});
+it( 'declares the expected fillable attributes on Role', function (): void {
+    expect( (new Role)->getFillable() )->toBe( ['name', 'slug', 'description', 'parent_id'] );
+} );
 
-it('declares the expected fillable attributes on Permission', function (): void {
-    expect((new Permission)->getFillable())->toBe(['name', 'slug', 'description']);
+it( 'declares the expected fillable attributes on Permission', function (): void {
+    expect( (new Permission)->getFillable() )->toBe( ['name', 'slug', 'description'] );
 });

--- a/tests/Unit/ModelFillableTest.php
+++ b/tests/Unit/ModelFillableTest.php
@@ -11,4 +11,4 @@ it( 'declares the expected fillable attributes on Role', function (): void {
 
 it( 'declares the expected fillable attributes on Permission', function (): void {
     expect( (new Permission)->getFillable() )->toBe( ['name', 'slug', 'description'] );
-});
+} );


### PR DESCRIPTION
## Summary

Brings the package up to the ArtisanPack UI ecosystem release standard (composer.json, LICENSE, README, CHANGELOG, CONTRIBUTING, docs/, PHPDoc, lint, tests) and bumps the version to 1.0.0.

See the commit body for the per-phase detail.

## Test plan

- [x] composer validate clean
- [x] composer lint clean
- [x] composer test all-green
- [ ] CodeRabbit auto-review on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Initial 1.0.0 RBAC package: roles, permissions, user traits, middleware, Blade directives, Gate integration, Artisan role/permission commands, migrations, events, and permission caching.

* **Documentation**
  * Comprehensive docs: Getting Started, Installation/Configuration, Usage, Advanced (caching/events/extending), FAQ, Troubleshooting, and sibling-package links.

* **Chores**
  * Package metadata bumped to 1.0.0; license → MIT; author contact updated; CI and release workflows added/updated; new GitHub Actions workflows included.

* **Style**
  * Repository-wide formatting and test file style standardization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/rbac/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->