### PR TITLE
feat: add role/ability lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Lifecycle hooks powered by `artisanpack-ui/hooks`:
+  - `ap.rbac.abilitiesForUser` filter — passes the resolved ability list through user-space filters, letting external packages graft permissions from LDAP, feature flags, or tenant policies onto a user without subclassing.
+  - `ap.rbac.role.assigned` action — fired from `HasRoles::assignRole()` after a role is attached, with `(User $user, Role $role)`.
+  - `ap.rbac.role.revoked` action — fired from `HasRoles::removeRole()` after a role is detached, with `(User $user, Role $role)`.
+  - `ap.rbac.checkingAbility` action — fired from the RBAC `Gate::before` shim before ability resolution, with `(User $user, string $ability, mixed $arguments)`, giving compliance-heavy apps a low-friction audit seam.
+- `HasPermissions::getAbilities()` — returns the flat list of ability strings (names + slugs) the user can perform, after the `ap.rbac.abilitiesForUser` filter has run. `hasPermissionTo()` now resolves through this method, so grafted abilities are honored by `$user->can()`, `Gate::allows()`, and `@can`.
+
+### Changed
+
+- `artisanpack-ui/hooks: ^1.3` is now a hard dependency. The rbac package no longer works without it — hook fire sites are called unconditionally.
+
 ## [1.0.1] - 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -271,6 +271,38 @@ Pivot mutations are dispatched directly from the trait helpers since Laravel doe
 
 Listen for these in any application or sibling package — `security-analytics` uses them for audit logging.
 
+## Hooks
+
+The package integrates with [`artisanpack-ui/hooks`](https://github.com/ArtisanPack-UI/hooks) to expose lifecycle seams that let external packages graft onto the role / permission flow without subclassing or event-listener boilerplate.
+
+| Hook | Type | Fired from | Payload |
+|---|---|---|---|
+| `ap.rbac.abilitiesForUser` | filter | `HasPermissions::getAbilities()` | `(array $abilities, User $user)` |
+| `ap.rbac.role.assigned` | action | `HasRoles::assignRole()` | `(User $user, Role $role)` |
+| `ap.rbac.role.revoked` | action | `HasRoles::removeRole()` | `(User $user, Role $role)` |
+| `ap.rbac.checkingAbility` | action | `Gate::before` (in the RBAC service provider) | `(User $user, string $ability, mixed $arguments)` |
+
+`ap.rbac.abilitiesForUser` is the canonical extension seam for grafting external permission sources (LDAP groups, feature flags, tenant policies) onto a user's ability set. `hasPermissionTo()` and Laravel's Gate resolve through this list, so grafted abilities are honored everywhere.
+
+`ap.rbac.checkingAbility` is an audit seam — every Gate check on a user carrying the `HasPermissions` trait fires it before RBAC resolution, whether or not the ability ends up matching an RBAC permission.
+
+```php
+use function addFilter;
+use function addAction;
+
+// Graft ability strings from an external source.
+addFilter( 'ap.rbac.abilitiesForUser', function ( array $abilities, $user ): array {
+    return array_merge( $abilities, resolveLdapGroups( $user ) );
+} );
+
+// Audit every ability check.
+addAction( 'ap.rbac.checkingAbility', function ( $user, string $ability, $arguments ): void {
+    Log::channel( 'audit' )->info( 'rbac.check', compact( 'user', 'ability', 'arguments' ) );
+} );
+```
+
+The sibling `ap.rbac.roleRegistered` and `ap.rbac.permissionRegistered` hooks are documented in and fired from `artisanpack-ui/cms-framework` — this package does not re-fire them.
+
 ## Testing
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
   "require": {
     "php": "^8.2",
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-    "artisanpack-ui/core": "^1.0"
+    "artisanpack-ui/core": "^1.0",
+    "artisanpack-ui/hooks": "^1.3"
   },
   "require-dev": {
     "pestphp/pest": "^3.8|^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "249167d6b61c80be7b1cdf013f0d7b38",
+    "content-hash": "d37f7d53880ad5d05ca6f4d79c2578c7",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -74,6 +74,72 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "artisanpack-ui/hooks",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/hooks.git",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Action": "ArtisanPackUI\\Hooks\\Facades\\Action",
+                        "Filter": "ArtisanPackUI\\Hooks\\Facades\\Filter"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Hooks\\Providers\\HooksServiceProvider",
+                        "ArtisanPackUI\\Hooks\\Providers\\BladeDirectiveServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Hooks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
+            },
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "brick/math",

--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -31,15 +31,30 @@ trait HasPermissions
 {
     public function hasPermissionTo( string $permission ): bool
     {
+        return in_array( $permission, $this->getAbilities(), true );
+    }
+
+    /**
+     * Return the flat list of ability strings this user can perform.
+     *
+     * Collects the `name` and `slug` of every permission reachable through
+     * the user's roles (walking the parent hierarchy), then passes the list
+     * through the `ap.rbac.abilitiesForUser` filter so external sources
+     * (LDAP groups, feature flags, tenant policies) can extend or override
+     * it.
+     *
+     * @return array<int, string>
+     */
+    public function getAbilities(): array
+    {
         $permissions = $this->resolvePermissions();
 
-        // Prefer name match; fall back to slug. This avoids ambiguity
-        // when one row's name happens to equal another row's slug.
-        if ( $permissions->contains( 'name', $permission ) ) {
-            return true;
-        }
+        $abilities = array_values( array_unique( array_merge(
+            $permissions->pluck( 'name' )->all(),
+            $permissions->pluck( 'slug' )->all(),
+        ) ) );
 
-        return $permissions->contains( 'slug', $permission );
+        return applyFilters( 'ap.rbac.abilitiesForUser', $abilities, $this );
     }
 
     /**

--- a/src/Concerns/HasRoles.php
+++ b/src/Concerns/HasRoles.php
@@ -69,6 +69,7 @@ trait HasRoles
         if ( null !== $resolved ) {
             $this->roles()->syncWithoutDetaching( [$resolved->getKey()] );
             Event::dispatch( 'rbac.user.role_assigned', [$this, $resolved] );
+            doAction( 'ap.rbac.role.assigned', $this, $resolved );
 
             if ( method_exists( $this, 'flushPermissionCache' ) ) {
                 $this->flushPermissionCache();
@@ -85,6 +86,7 @@ trait HasRoles
         if ( null !== $resolved ) {
             $this->roles()->detach( $resolved->getKey() );
             Event::dispatch( 'rbac.user.role_removed', [$this, $resolved] );
+            doAction( 'ap.rbac.role.revoked', $this, $resolved );
 
             if ( method_exists( $this, 'flushPermissionCache' ) ) {
                 $this->flushPermissionCache();

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -151,10 +151,12 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerGate(): void
     {
-        Gate::before( function ( $user, $ability ) {
+        Gate::before( function ( $user, $ability, $arguments = [] ) {
             if ( ! method_exists( $user, 'hasPermissionTo' ) ) {
                 return null;
             }
+
+            doAction( 'ap.rbac.checkingAbility', $user, $ability, $arguments );
 
             $permissionNames = $this->getCachedPermissionNames();
 

--- a/tests/Feature/HooksTest.php
+++ b/tests/Feature/HooksTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Hooks\Facades\Action;
+use ArtisanPackUI\Hooks\Facades\Filter;
+use ArtisanPackUI\Rbac\Models\Permission;
+use ArtisanPackUI\Rbac\Models\Role;
+use Illuminate\Support\Facades\Gate;
+use Tests\Models\TestUser;
+
+afterEach( function (): void {
+    Action::removeAll( 'ap.rbac.role.assigned' );
+    Action::removeAll( 'ap.rbac.role.revoked' );
+    Action::removeAll( 'ap.rbac.checkingAbility' );
+    Filter::removeAll( 'ap.rbac.abilitiesForUser' );
+} );
+
+it( 'fires ap.rbac.role.assigned when a role is assigned', function (): void {
+    $captured = [];
+    addAction( 'ap.rbac.role.assigned', function ( $user, $role ) use ( &$captured ): void {
+        $captured[] = [$user, $role];
+    } );
+
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'assigned@example.com'] );
+    Role::create( ['name' => 'admin'] );
+
+    $user->assignRole( 'admin' );
+
+    expect( $captured )->toHaveCount( 1 );
+    expect( $captured[0][0]->id )->toBe( $user->id );
+    expect( $captured[0][1]->name )->toBe( 'admin' );
+} );
+
+it( 'does not fire ap.rbac.role.assigned when the role does not exist', function (): void {
+    $fired = false;
+    addAction( 'ap.rbac.role.assigned', function () use ( &$fired ): void {
+        $fired = true;
+    } );
+
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'ghost@example.com'] );
+    $user->assignRole( 'ghost' );
+
+    expect( $fired )->toBeFalse();
+} );
+
+it( 'fires ap.rbac.role.revoked when a role is removed', function (): void {
+    $captured = [];
+    addAction( 'ap.rbac.role.revoked', function ( $user, $role ) use ( &$captured ): void {
+        $captured[] = [$user, $role];
+    } );
+
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'revoked@example.com'] );
+    Role::create( ['name' => 'admin'] );
+    $user->assignRole( 'admin' );
+
+    $user->removeRole( 'admin' );
+
+    expect( $captured )->toHaveCount( 1 );
+    expect( $captured[0][1]->name )->toBe( 'admin' );
+} );
+
+it( 'exposes ap.rbac.abilitiesForUser as a filter on the resolved list', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'abilities@example.com'] );
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
+
+    addFilter( 'ap.rbac.abilitiesForUser', function ( array $abilities, $filteredUser ) {
+        $abilities[] = 'grafted-from-ldap';
+        return $abilities;
+    } );
+
+    $abilities = $user->getAbilities();
+
+    expect( $abilities )->toContain( 'edit-articles' );
+    expect( $abilities )->toContain( 'grafted-from-ldap' );
+} );
+
+it( 'grafted abilities from the filter satisfy hasPermissionTo and Gate checks', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'grafted@example.com'] );
+    $role = Role::create( ['name' => 'editor'] );
+    $user->roles()->attach( $role );
+
+    addFilter( 'ap.rbac.abilitiesForUser', function ( array $abilities ) {
+        $abilities[] = 'ldap-only';
+        return $abilities;
+    } );
+
+    // Register 'ldap-only' as a known permission so Gate::before matches it.
+    Permission::create( ['name' => 'ldap-only'] );
+
+    expect( $user->hasPermissionTo( 'ldap-only' ) )->toBeTrue();
+    expect( $user->can( 'ldap-only' ) )->toBeTrue();
+} );
+
+it( 'fires ap.rbac.checkingAbility before each Gate check', function (): void {
+    $captured = [];
+    addAction( 'ap.rbac.checkingAbility', function ( $user, $ability, $arguments ) use ( &$captured ): void {
+        $captured[] = [$user->id, $ability, $arguments];
+    } );
+
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'checking@example.com'] );
+    Permission::create( ['name' => 'publish' ] );
+
+    Gate::forUser( $user )->allows( 'publish' );
+
+    expect( $captured )->toHaveCount( 1 );
+    expect( $captured[0][1] )->toBe( 'publish' );
+    expect( $captured[0][2] )->toBeArray();
+} );


### PR DESCRIPTION
## Description

Wires four `ap.rbac.*` lifecycle hooks into the rbac package via `artisanpack-ui/hooks: ^1.3` (now a hard runtime dependency, so no `function_exists` gates are needed at the fire sites).

**Closes:** #20

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #20

## Motivation and Context

Wave 5 of the cross-package hooks standardization. `cms-framework` already fires `ap.rbac.roleRegistered` and `ap.rbac.permissionRegistered` (Wave 4a). This PR adds the four remaining rbac-owned lifecycle seams so external packages can graft onto ability resolution and audit every ability check without subclassing.

## Changes Made

- **`ap.rbac.abilitiesForUser`** (filter) — fires from the new `HasPermissions::getAbilities()` method, which returns the flat name+slug ability list. `hasPermissionTo()` now resolves through this method, so grafted abilities (LDAP groups, feature flags, tenant policies) are honored by `$user->can()`, `Gate::allows()`, and `@can`.
- **`ap.rbac.role.assigned`** (action) — fires from `HasRoles::assignRole()` after a successful attach, alongside the legacy `rbac.user.role_assigned` Laravel event.
- **`ap.rbac.role.revoked`** (action) — fires from `HasRoles::removeRole()` after a successful detach.
- **`ap.rbac.checkingAbility`** (action) — fires from the RBAC `Gate::before` shim before ability resolution. Audit seam for compliance-heavy apps.
- Bumped composer dep: `artisanpack-ui/hooks: ^1.3` (required, not suggested).
- README: new **Hooks** section documenting the four seams + a cross-reference note pointing at cms-framework as the owner of `ap.rbac.roleRegistered` / `permissionRegistered`.
- CHANGELOG: Unreleased entry.

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.5.7 (composer platform pinned to 8.2)
- Project Version: `feature/20-rbac-lifecycle-hooks` off `release/1.1`

**Tests Performed:**
1. `./vendor/bin/pest` — 83 passed (138 assertions), including 6 new hook-specific tests.
2. `./vendor/bin/php-cs-fixer fix` — no changes needed.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/HooksTest.php` — one test per hook plus a regression asserting that grafted abilities from `ap.rbac.abilitiesForUser` satisfy both `hasPermissionTo()` and `$user->can()`.

## Documentation

- [x] Inline code documentation added
- [x] README updated

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed