### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-21
+
 ### Added
 
 - Lifecycle hooks powered by `artisanpack-ui/hooks`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Lifecycle hooks powered by `artisanpack-ui/hooks`:
+  - `ap.rbac.abilitiesForUser` filter — passes the resolved ability list through user-space filters, letting external packages graft permissions from LDAP, feature flags, or tenant policies onto a user without subclassing.
+  - `ap.rbac.role.assigned` action — fired from `HasRoles::assignRole()` after a role is attached, with `(User $user, Role $role)`.
+  - `ap.rbac.role.revoked` action — fired from `HasRoles::removeRole()` after a role is detached, with `(User $user, Role $role)`.
+  - `ap.rbac.checkingAbility` action — fired from the RBAC `Gate::before` shim before ability resolution, with `(User $user, string $ability, mixed $arguments)`, giving compliance-heavy apps a low-friction audit seam.
+- `HasPermissions::getAbilities()` — returns the flat list of ability strings (names + slugs) the user can perform, after the `ap.rbac.abilitiesForUser` filter has run. `hasPermissionTo()` now resolves through this method, so grafted abilities are honored by `$user->can()`, `Gate::allows()`, and `@can`.
+
+### Changed
+
+- `artisanpack-ui/hooks: ^1.3` is now a hard dependency. The rbac package no longer works without it — hook fire sites are called unconditionally.
+
 ## [1.0.1] - 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -271,6 +271,38 @@ Pivot mutations are dispatched directly from the trait helpers since Laravel doe
 
 Listen for these in any application or sibling package — `security-analytics` uses them for audit logging.
 
+## Hooks
+
+The package integrates with [`artisanpack-ui/hooks`](https://github.com/ArtisanPack-UI/hooks) to expose lifecycle seams that let external packages graft onto the role / permission flow without subclassing or event-listener boilerplate.
+
+| Hook | Type | Fired from | Payload |
+|---|---|---|---|
+| `ap.rbac.abilitiesForUser` | filter | `HasPermissions::getAbilities()` | `(array $abilities, User $user)` |
+| `ap.rbac.role.assigned` | action | `HasRoles::assignRole()` | `(User $user, Role $role)` |
+| `ap.rbac.role.revoked` | action | `HasRoles::removeRole()` | `(User $user, Role $role)` |
+| `ap.rbac.checkingAbility` | action | `Gate::before` (in the RBAC service provider) | `(User $user, string $ability, mixed $arguments)` |
+
+`ap.rbac.abilitiesForUser` is the canonical extension seam for grafting external permission sources (LDAP groups, feature flags, tenant policies) onto a user's ability set. `hasPermissionTo()` and Laravel's Gate resolve through this list, so grafted abilities are honored everywhere.
+
+`ap.rbac.checkingAbility` is an audit seam — every Gate check on a user carrying the `HasPermissions` trait fires it before RBAC resolution, whether or not the ability ends up matching an RBAC permission.
+
+```php
+use function addFilter;
+use function addAction;
+
+// Graft ability strings from an external source.
+addFilter( 'ap.rbac.abilitiesForUser', function ( array $abilities, $user ): array {
+    return array_merge( $abilities, resolveLdapGroups( $user ) );
+} );
+
+// Audit every ability check.
+addAction( 'ap.rbac.checkingAbility', function ( $user, string $ability, $arguments ): void {
+    Log::channel( 'audit' )->info( 'rbac.check', compact( 'user', 'ability', 'arguments' ) );
+} );
+```
+
+The sibling `ap.rbac.roleRegistered` and `ap.rbac.permissionRegistered` hooks are documented in and fired from `artisanpack-ui/cms-framework` — this package does not re-fire them.
+
 ## Testing
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Role-based access control for Laravel — roles with hierarchy, permissions, Blade directives, middleware, and Gate integration.",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "keywords": [
     "laravel",
     "security",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
   "require": {
     "php": "^8.2",
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-    "artisanpack-ui/core": "^1.0"
+    "artisanpack-ui/core": "^1.0",
+    "artisanpack-ui/hooks": "^1.3"
   },
   "require-dev": {
     "pestphp/pest": "^3.8|^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "249167d6b61c80be7b1cdf013f0d7b38",
+    "content-hash": "d37f7d53880ad5d05ca6f4d79c2578c7",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -74,6 +74,72 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "artisanpack-ui/hooks",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/hooks.git",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Action": "ArtisanPackUI\\Hooks\\Facades\\Action",
+                        "Filter": "ArtisanPackUI\\Hooks\\Facades\\Filter"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Hooks\\Providers\\HooksServiceProvider",
+                        "ArtisanPackUI\\Hooks\\Providers\\BladeDirectiveServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Hooks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
+            },
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "brick/math",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d37f7d53880ad5d05ca6f4d79c2578c7",
+    "content-hash": "a25ff15733113b78b20af84d13b4ed4e",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -10,4 +10,5 @@ Topics beyond the day-to-day usage path.
 
 - [Extending the base models](advanced/extending-models.md) — substitute your own `Role` / `Permission` subclasses without forking the package
 - [Events](advanced/events.md) — observer + pivot events you can subscribe to
+- [Hooks](advanced/hooks.md) — `artisanpack-ui/hooks` seams for grafting abilities and auditing Gate checks (v1.1.0+)
 - [Caching](advanced/caching.md) — how the two caches work, TTLs, invalidation rules, tuning

--- a/docs/advanced/hooks.md
+++ b/docs/advanced/hooks.md
@@ -1,0 +1,81 @@
+---
+title: Hooks
+---
+
+# Hooks
+
+Since v1.1.0, the package integrates with [`artisanpack-ui/hooks`](https://github.com/ArtisanPack-UI/hooks) to expose lifecycle seams that let external packages graft onto the role / permission flow without subclassing traits or wiring up event listeners.
+
+Hooks complement — they do not replace — the [Events](events.md) system. Events are best for coarse-grained observation (audit logging, notifications); hooks are best for extension seams where the package needs to compose the return value with contributions from other packages (filters) or expose a low-friction audit / policy seam that fires unconditionally on every call (actions).
+
+## Hook reference
+
+| Hook | Type | Fired from | Payload |
+|---|---|---|---|
+| `ap.rbac.abilitiesForUser` | filter | `HasPermissions::getAbilities()` | `(array $abilities, User $user)` |
+| `ap.rbac.role.assigned` | action | `HasRoles::assignRole()` | `(User $user, Role $role)` |
+| `ap.rbac.role.revoked` | action | `HasRoles::removeRole()` | `(User $user, Role $role)` |
+| `ap.rbac.checkingAbility` | action | `Gate::before` (registered by `RbacServiceProvider`) | `(User $user, string $ability, mixed $arguments)` |
+
+The `role.assigned` and `role.revoked` actions fire only when the pivot actually changes state — identical to their sibling `rbac.user.role_assigned` / `rbac.user.role_removed` events.
+
+## `ap.rbac.abilitiesForUser`
+
+The canonical extension seam. `HasPermissions::getAbilities()` collects every ability reachable through the user's role hierarchy (both `name` and `slug` for each permission), then passes the flat, de-duplicated list through this filter. Because `hasPermissionTo()`, `$user->can('slug')`, `Gate::allows('slug')`, and `@can('slug')` all resolve through `getAbilities()`, anything a filter grafts on is honored everywhere.
+
+Typical use cases:
+
+- Graft ability strings from an external directory (LDAP groups, Okta, Azure AD).
+- Merge feature-flag-derived abilities so a flag flip immediately widens or narrows what `@can` renders.
+- Overlay tenant-specific abilities in a multi-tenant app.
+
+```php
+use function addFilter;
+
+addFilter( 'ap.rbac.abilitiesForUser', function ( array $abilities, $user ): array {
+    return array_merge( $abilities, resolveLdapGroups( $user ) );
+} );
+```
+
+The filter fires inside the resolved-permissions path, which sits behind the per-user permission cache. If your external source changes and you need the next `getAbilities()` call to see the new value, invalidate that cache with `$user->flushPermissionCache()`.
+
+## `ap.rbac.role.assigned` / `ap.rbac.role.revoked`
+
+Actions dispatched from `HasRoles::assignRole()` and `HasRoles::removeRole()` after the pivot mutation succeeds and after the sibling `rbac.user.role_assigned` / `rbac.user.role_removed` events fire.
+
+They exist alongside the events so downstream packages that already speak the hooks vocabulary (cms-framework, security-analytics extensions) can subscribe without setting up Laravel event listeners for a single side effect.
+
+```php
+use function addAction;
+
+addAction( 'ap.rbac.role.assigned', function ( $user, $role ): void {
+    dispatch( new SyncRoleToIdp( $user, $role ) );
+} );
+```
+
+Pivot mutations that bypass the trait helpers (`$user->roles()->attach($id)` etc.) do **not** fire either the events or the hooks.
+
+## `ap.rbac.checkingAbility`
+
+An audit seam. Every Gate check on a user carrying the `HasPermissions` trait triggers this action from the RBAC `Gate::before` shim, before the shim decides whether the ability matches an RBAC permission and before the shim falls through to standard policies. It fires unconditionally per call — matching abilities and non-matching abilities both surface here.
+
+This is deliberate: compliance-heavy applications typically need to log every attempted authorization decision, not just the ones that ended up hitting an RBAC row.
+
+```php
+use function addAction;
+use Illuminate\Support\Facades\Log;
+
+addAction( 'ap.rbac.checkingAbility', function ( $user, string $ability, $arguments ): void {
+    Log::channel( 'audit' )->info( 'rbac.check', [
+        'user_id'   => $user->getKey(),
+        'ability'   => $ability,
+        'arguments' => $arguments,
+    ] );
+} );
+```
+
+Because this fires from `Gate::before`, it runs on **every** ability check on the user — including checks that end up handled by non-RBAC policies. Keep the listener cheap or defer heavy work (queued jobs, buffered log flushes) to avoid making Gate checks a hot path.
+
+## Related packages
+
+The sibling hooks `ap.rbac.roleRegistered` and `ap.rbac.permissionRegistered` are documented in and fired from [`artisanpack-ui/cms-framework`](https://github.com/ArtisanPack-UI/cms-framework) when it discovers and registers roles / permissions declared by packages. This package does not re-fire them.

--- a/docs/home.md
+++ b/docs/home.md
@@ -19,6 +19,7 @@ This package is **standalone** — it does not depend on `artisanpack-ui/securit
 - Artisan commands for CRUD over roles and role assignments
 - Configurable model bindings so consumers can extend `Role` / `Permission` with their own subclasses
 - Eloquent observer events on the `rbac.*` channel for downstream auditing
+- `artisanpack-ui/hooks` lifecycle seams (`ap.rbac.*`) for grafting abilities from external sources and auditing Gate checks
 
 ## Documentation map
 

--- a/docs/usage/user-traits.md
+++ b/docs/usage/user-traits.md
@@ -55,6 +55,7 @@ Resolves the user's effective permission set by walking the role hierarchy. Requ
 ```php
 $user->hasPermissionTo('posts.publish');   // bool
 $user->hasPermission('posts.publish');     // alias of hasPermissionTo
+$user->getAbilities();                     // array<int, string> — flat ability list
 $user->flushPermissionCache();             // call after manual pivot mutations
 ```
 
@@ -63,7 +64,10 @@ $user->flushPermissionCache();             // call after manual pivot mutations
 1. Load the user's direct roles via `HasRoles::roles()`.
 2. For each role, walk up the `parent` chain collecting permissions at each level.
 3. Union the resulting permission collection and cache it under a per-user cache key for `artisanpack.rbac.cache.user_permissions_ttl` seconds (default 60).
-4. Return `true` if either the permission's `name` or `slug` matches the supplied string.
+4. `getAbilities()` flattens the collection into a de-duplicated array of ability strings (each permission contributes both its `name` and its `slug`) and runs it through the `ap.rbac.abilitiesForUser` filter so external sources can graft additional abilities onto the user.
+5. `hasPermissionTo()` returns `true` if the supplied string appears anywhere in `getAbilities()`.
+
+See [Hooks](../advanced/hooks.md) for the filter contract and grafting patterns.
 
 ### Manual cache invalidation
 

--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -31,15 +31,30 @@ trait HasPermissions
 {
     public function hasPermissionTo( string $permission ): bool
     {
+        return in_array( $permission, $this->getAbilities(), true );
+    }
+
+    /**
+     * Return the flat list of ability strings this user can perform.
+     *
+     * Collects the `name` and `slug` of every permission reachable through
+     * the user's roles (walking the parent hierarchy), then passes the list
+     * through the `ap.rbac.abilitiesForUser` filter so external sources
+     * (LDAP groups, feature flags, tenant policies) can extend or override
+     * it.
+     *
+     * @return array<int, string>
+     */
+    public function getAbilities(): array
+    {
         $permissions = $this->resolvePermissions();
 
-        // Prefer name match; fall back to slug. This avoids ambiguity
-        // when one row's name happens to equal another row's slug.
-        if ( $permissions->contains( 'name', $permission ) ) {
-            return true;
-        }
+        $abilities = array_values( array_unique( array_merge(
+            $permissions->pluck( 'name' )->all(),
+            $permissions->pluck( 'slug' )->all(),
+        ) ) );
 
-        return $permissions->contains( 'slug', $permission );
+        return applyFilters( 'ap.rbac.abilitiesForUser', $abilities, $this );
     }
 
     /**

--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -43,6 +43,8 @@ trait HasPermissions
      * (LDAP groups, feature flags, tenant policies) can extend or override
      * it.
      *
+     * @since 1.1.0
+     *
      * @return array<int, string>
      */
     public function getAbilities(): array

--- a/src/Concerns/HasRoles.php
+++ b/src/Concerns/HasRoles.php
@@ -69,6 +69,7 @@ trait HasRoles
         if ( null !== $resolved ) {
             $this->roles()->syncWithoutDetaching( [$resolved->getKey()] );
             Event::dispatch( 'rbac.user.role_assigned', [$this, $resolved] );
+            doAction( 'ap.rbac.role.assigned', $this, $resolved );
 
             if ( method_exists( $this, 'flushPermissionCache' ) ) {
                 $this->flushPermissionCache();
@@ -85,6 +86,7 @@ trait HasRoles
         if ( null !== $resolved ) {
             $this->roles()->detach( $resolved->getKey() );
             Event::dispatch( 'rbac.user.role_removed', [$this, $resolved] );
+            doAction( 'ap.rbac.role.revoked', $this, $resolved );
 
             if ( method_exists( $this, 'flushPermissionCache' ) ) {
                 $this->flushPermissionCache();

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -151,10 +151,12 @@ class RbacServiceProvider extends ServiceProvider
      */
     protected function registerGate(): void
     {
-        Gate::before( function ( $user, $ability ) {
+        Gate::before( function ( $user, $ability, $arguments = [] ) {
             if ( ! method_exists( $user, 'hasPermissionTo' ) ) {
                 return null;
             }
+
+            doAction( 'ap.rbac.checkingAbility', $user, $ability, $arguments );
 
             $permissionNames = $this->getCachedPermissionNames();
 

--- a/tests/Feature/HooksTest.php
+++ b/tests/Feature/HooksTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Hooks\Facades\Action;
+use ArtisanPackUI\Hooks\Facades\Filter;
+use ArtisanPackUI\Rbac\Models\Permission;
+use ArtisanPackUI\Rbac\Models\Role;
+use Illuminate\Support\Facades\Gate;
+use Tests\Models\TestUser;
+
+afterEach( function (): void {
+    Action::removeAll( 'ap.rbac.role.assigned' );
+    Action::removeAll( 'ap.rbac.role.revoked' );
+    Action::removeAll( 'ap.rbac.checkingAbility' );
+    Filter::removeAll( 'ap.rbac.abilitiesForUser' );
+} );
+
+it( 'fires ap.rbac.role.assigned when a role is assigned', function (): void {
+    $captured = [];
+    addAction( 'ap.rbac.role.assigned', function ( $user, $role ) use ( &$captured ): void {
+        $captured[] = [$user, $role];
+    } );
+
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'assigned@example.com'] );
+    Role::create( ['name' => 'admin'] );
+
+    $user->assignRole( 'admin' );
+
+    expect( $captured )->toHaveCount( 1 );
+    expect( $captured[0][0]->id )->toBe( $user->id );
+    expect( $captured[0][1]->name )->toBe( 'admin' );
+} );
+
+it( 'does not fire ap.rbac.role.assigned when the role does not exist', function (): void {
+    $fired = false;
+    addAction( 'ap.rbac.role.assigned', function () use ( &$fired ): void {
+        $fired = true;
+    } );
+
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'ghost@example.com'] );
+    $user->assignRole( 'ghost' );
+
+    expect( $fired )->toBeFalse();
+} );
+
+it( 'fires ap.rbac.role.revoked when a role is removed', function (): void {
+    $captured = [];
+    addAction( 'ap.rbac.role.revoked', function ( $user, $role ) use ( &$captured ): void {
+        $captured[] = [$user, $role];
+    } );
+
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'revoked@example.com'] );
+    Role::create( ['name' => 'admin'] );
+    $user->assignRole( 'admin' );
+
+    $user->removeRole( 'admin' );
+
+    expect( $captured )->toHaveCount( 1 );
+    expect( $captured[0][1]->name )->toBe( 'admin' );
+} );
+
+it( 'exposes ap.rbac.abilitiesForUser as a filter on the resolved list', function (): void {
+    $user       = TestUser::create( ['name' => 'Test', 'email' => 'abilities@example.com'] );
+    $role       = Role::create( ['name' => 'editor'] );
+    $permission = Permission::create( ['name' => 'edit-articles'] );
+    $role->permissions()->attach( $permission );
+    $user->roles()->attach( $role );
+
+    addFilter( 'ap.rbac.abilitiesForUser', function ( array $abilities, $filteredUser ) {
+        $abilities[] = 'grafted-from-ldap';
+        return $abilities;
+    } );
+
+    $abilities = $user->getAbilities();
+
+    expect( $abilities )->toContain( 'edit-articles' );
+    expect( $abilities )->toContain( 'grafted-from-ldap' );
+} );
+
+it( 'grafted abilities from the filter satisfy hasPermissionTo and Gate checks', function (): void {
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'grafted@example.com'] );
+    $role = Role::create( ['name' => 'editor'] );
+    $user->roles()->attach( $role );
+
+    addFilter( 'ap.rbac.abilitiesForUser', function ( array $abilities ) {
+        $abilities[] = 'ldap-only';
+        return $abilities;
+    } );
+
+    // Register 'ldap-only' as a known permission so Gate::before matches it.
+    Permission::create( ['name' => 'ldap-only'] );
+
+    expect( $user->hasPermissionTo( 'ldap-only' ) )->toBeTrue();
+    expect( $user->can( 'ldap-only' ) )->toBeTrue();
+} );
+
+it( 'fires ap.rbac.checkingAbility before each Gate check', function (): void {
+    $captured = [];
+    addAction( 'ap.rbac.checkingAbility', function ( $user, $ability, $arguments ) use ( &$captured ): void {
+        $captured[] = [$user->id, $ability, $arguments];
+    } );
+
+    $user = TestUser::create( ['name' => 'Test', 'email' => 'checking@example.com'] );
+    Permission::create( ['name' => 'publish' ] );
+
+    Gate::forUser( $user )->allows( 'publish' );
+
+    expect( $captured )->toHaveCount( 1 );
+    expect( $captured[0][1] )->toBe( 'publish' );
+    expect( $captured[0][2] )->toBeArray();
+} );


### PR DESCRIPTION
<!--- Title format: Release v1.0.0 -->


## Release Information

- **Release Version:** v1.1.0
- **Release Date:** 2026-07-21
- **Release Type:** Minor
- **Release Branch:** `release/1.1`
- **Target Branch:** `main`

## Release Summary

v1.1.0 wires the `artisanpack-ui/hooks` package into the RBAC lifecycle. It exposes a canonical extension seam for grafting abilities onto a user from external sources (LDAP, feature flags, tenant policies), plus lifecycle actions on role assignment / removal and a low-friction audit seam on every Gate check.

`artisanpack-ui/hooks: ^1.3` becomes a hard dependency — the package fires hooks unconditionally and no longer works without it.

## Changelog

### Added

- Lifecycle hooks powered by `artisanpack-ui/hooks`:
  - `ap.rbac.abilitiesForUser` filter — passes the resolved ability list through user-space filters so external packages can graft permissions from LDAP, feature flags, or tenant policies onto a user without subclassing.
  - `ap.rbac.role.assigned` action — fired from `HasRoles::assignRole()` after a role is attached, with `(User $user, Role $role)`.
  - `ap.rbac.role.revoked` action — fired from `HasRoles::removeRole()` after a role is detached, with `(User $user, Role $role)`.
  - `ap.rbac.checkingAbility` action — fired from the RBAC `Gate::before` shim before ability resolution, with `(User $user, string $ability, mixed $arguments)`.
- `HasPermissions::getAbilities()` — returns the flat list of ability strings the user can perform, after the `ap.rbac.abilitiesForUser` filter has run. `hasPermissionTo()` resolves through this method, so grafted abilities are honored by `$user->can()`, `Gate::allows()`, and `@can`.
- New `docs/advanced/hooks.md` documenting the four hooks, the extension patterns, and the interaction with the existing event system.

### Changed

- `artisanpack-ui/hooks: ^1.3` is now a hard dependency. The package no longer works without it — hook fire sites are called unconditionally.

### Deprecated

- (none)

### Removed

- (none)

### Fixed

- (none)

### Security

- (none)

## Issues and Pull Requests

**Related PRs:**
- #21 — feat: add role/ability lifecycle hooks

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

`artisanpack-ui/hooks` becomes a hard dependency, but it was already an ecosystem-standard package and Composer resolves it transparently. No API changes to existing traits, facades, middleware, or Blade directives.

## Testing Checklist

- [x] All automated tests passing (83 tests, 138 assertions via Pest)
- [ ] Manual testing completed
- [ ] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [x] Security scan completed — see notes
- [ ] Tested in staging environment
- [ ] Database migrations tested (if applicable) — no new migrations

**Testing notes:**

`composer audit` reports 9 medium-severity advisories against `guzzlehttp/guzzle` and `guzzlehttp/psr7`. Both are dev-only transitive dependencies pulled in by `orchestra/testbench` and do not ship in the package's production dependency tree. Not blocking for the release.

## Documentation Checklist

- [x] CHANGELOG updated ([1.1.0] section with 2026-07-21 date; new empty [Unreleased] above)
- [x] README updated — Hooks section added
- [x] API documentation updated — `docs/advanced/hooks.md` added; `docs/usage/user-traits.md` documents `getAbilities()`; `docs/home.md` + `docs/advanced.md` link the new page
- [x] Migration guide written (if breaking changes) — n/a
- [x] Release notes written (this PR body)
- [ ] Wiki updated (if applicable)

## Pre-Release Checklist

- [x] Version number updated in all necessary files — only `composer.json` carried a live version string; existing `@since 1.0.0` tags on preexisting code left in place
- [ ] Git tag prepared: `v1.1.0`
- [x] Release branch created/updated: `release/1.1`
- [x] Dependencies updated and tested — `composer.lock` synced, `composer validate` clean
- [ ] Build artifacts generated — n/a (source package)
- [ ] Deployment plan reviewed — Packagist auto-picks up the tag
- [ ] Rollback plan prepared
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR into `main`.
2. Tag `main` with `v1.1.0` and push the tag.
3. Packagist auto-updates from the tag; downstream consumers pick it up on their next `composer update artisanpack-ui/rbac`.

**Rollback plan:**
1. Delete the `v1.1.0` tag from GitHub / Packagist.
2. Revert the merge commit on `main`.

**Configuration changes:**
- None. No config keys added or removed.

**Environment variables:**
- None.

## Post-Release Tasks

- [ ] Tag created: `v1.1.0`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

Downstream `artisanpack-ui/cms-framework` already speaks the `ap.rbac.roleRegistered` / `ap.rbac.permissionRegistered` sibling hooks; those live in cms-framework and are unchanged by this release.

---

**Release Manager:** @jacobmartella
**Reviewers Required:** @jacobmartella

**For Reviewers:**
- Verify all checklist items completed
- Review changelog accuracy
- Confirm version numbers correct
- Check breaking changes documented
- Approve deployment plan